### PR TITLE
Wire editorial calendar to live analytics, add docs

### DIFF
--- a/.claude/skills/editorial-performance/SKILL.md
+++ b/.claude/skills/editorial-performance/SKILL.md
@@ -8,30 +8,19 @@ user_invocable: true
 
 Pull analytics for published posts and flag those needing attention.
 
-## Dependency
-
-This skill requires the **automated-analytics** feature (oletizi/audiocontrol.org#30) to be implemented. Specifically:
-- Phase 3: Actionable Report & Recommendations (oletizi/audiocontrol.org#38)
-
-If the analytics pipeline is not yet available, report that to the user with a link to the dependency issue and stop.
-
 ## Steps
 
-1. **Check analytics availability**: Verify the analytics report script exists
-   - If not available: report the dependency gap and stop
-2. **Read the calendar**: Read `docs/editorial-calendar.md` to get the list of Published entries
-3. **Pull analytics**: For each published post, fetch:
-   - Pageviews and sessions (GA4)
+1. **Read the calendar**: Read `docs/editorial-calendar.md` to get the list of Published entries
+2. **Run analytics**: Execute `tsx scripts/analytics-report.ts --json` to fetch live analytics data
+3. **Match posts to metrics**: For each published post, gather:
+   - Pageviews and sessions (Umami/GA4)
    - Search impressions, clicks, CTR, average position (Search Console)
-4. **Identify underperformers**: Flag posts that show:
-   - Declining traffic trend (compared to previous period)
-   - High impressions but low CTR (title/description may need improvement)
-   - Dropping average position (content may need freshening)
-5. **Generate recommendations**: For each flagged post, provide specific suggestions:
-   - "Update title/description — 500 impressions but 1.2% CTR"
-   - "Add content about X — related query Y has 300 impressions at position 15"
-   - "Refresh content — position dropped from 5 to 12 in the last period"
-6. **Report**: Show a performance table:
+   - Recommendations from the analytics engine
+4. **Flag underperformers**: Posts that have recommendations from the analytics engine:
+   - High impressions but low CTR (title/description needs improvement)
+   - High bounce rate (content or UX issue)
+   - Striking-distance rankings (could be boosted with updates)
+5. **Report**: Show a performance table and recommendations:
    ```
    Published Posts Performance:
 
@@ -44,8 +33,16 @@ If the analytics pipeline is not yet available, report that to the user with a l
    - scsi-over-wifi-raspberry-pi-bridge: High impressions but low CTR — consider updating title and meta description
    ```
 
+## Implementation
+
+The `getPostPerformance()` function in `scripts/lib/editorial/suggest.ts` handles steps 2-4. It:
+- Calls the analytics pipeline (Umami, GA4, Search Console)
+- Matches each published entry to its metrics across all data sources
+- Collects recommendations from the analytics recommendation engine
+- Sorts results with underperformers first
+
 ## Important
 
-- All metrics must come from real analytics data — never fabricate numbers
+- All metrics come from real analytics data — never fabricate numbers
 - Flag posts with specific, actionable recommendations — not generic advice
-- Compare against the post's own history, not arbitrary thresholds
+- Posts with no analytics data should be reported as "No data" rather than skipped

--- a/.claude/skills/editorial-suggest/SKILL.md
+++ b/.claude/skills/editorial-suggest/SKILL.md
@@ -8,34 +8,28 @@ user_invocable: true
 
 Analyze analytics data and suggest content opportunities to add to the editorial calendar.
 
-## Dependency
-
-This skill requires the **automated-analytics** feature (oletizi/audiocontrol.org#30) to be implemented. Specifically:
-- Phase 1: GA4 Data Pipeline (oletizi/audiocontrol.org#36)
-- Phase 2: Search Console Integration (oletizi/audiocontrol.org#37)
-
-If the analytics pipeline is not yet available, report that to the user with a link to the dependency issue and stop.
-
 ## Steps
 
-1. **Check analytics availability**: Verify the analytics report script exists
-   - If not available: report the dependency gap and stop
-2. **Run analytics report**: Invoke the analytics pipeline to get:
-   - Search Console query data (impressions, position, CTR)
-   - Content gap analysis
-   - Striking-distance queries (positions 8-20)
-3. **Identify opportunities**: Filter and rank suggestions:
-   - High-impression queries with no matching content on the site
-   - Striking-distance queries that a new or updated post could push to page 1
-   - Content gaps where competitors rank but audiocontrol.org doesn't
-4. **Read the calendar**: Read `docs/editorial-calendar.md`
-5. **Deduplicate**: Filter out topics that already exist in the calendar
-6. **Present to user**: Show ranked suggestions with evidence:
+1. **Read the calendar**: Read `docs/editorial-calendar.md`
+2. **Run analytics**: Execute `tsx scripts/analytics-report.ts --json` to fetch live analytics data
+3. **Identify opportunities** from the report:
+   - **Striking-distance queries** (position 5-20): queries where new or expanded content could push to page 1
+   - **CTR opportunities**: high-impression queries with low CTR — title/description may need rewriting
+   - **Content gaps**: queries with impressions but no matching calendar entry
+4. **Deduplicate**: Filter out topics that already exist in the calendar
+5. **Present to user**: Show ranked suggestions with evidence:
    ```
    1. "SCSI protocol tutorial" — 450 impressions, position 12, no page targets this
    2. "Roland S-550 vs S-330" — 200 impressions, position 18, striking distance
    ```
-7. **Accept suggestions**: If the user picks suggestions to add, use `/editorial-add` to add them to Ideas with `source: analytics`
+6. **Accept suggestions**: If the user picks suggestions to add, use `/editorial-add` to add them to Ideas with `source: analytics`
+
+## Implementation
+
+The `getContentSuggestions()` function in `scripts/lib/editorial/suggest.ts` handles steps 2-4. It:
+- Calls the analytics pipeline (Umami, GA4, Search Console)
+- Extracts striking-distance and CTR opportunities
+- Deduplicates against existing calendar entries
 
 ## Important
 

--- a/CONTENT-CALENDAR.md
+++ b/CONTENT-CALENDAR.md
@@ -1,0 +1,139 @@
+# Content Calendar
+
+The content calendar tracks blog posts through their lifecycle from idea to publication, with analytics integration that closes the feedback loop: analytics data drives topic selection, and published post performance feeds back into planning.
+
+## How It Works
+
+Content moves through five stages:
+
+```
+Ideas  →  Planned  →  Drafting  →  Review  →  Published
+```
+
+Each stage is a section in `docs/editorial-calendar.md` — a markdown file with one table per stage. The file is both human-readable and machine-parseable.
+
+### Stages
+
+| Stage | What happens | Entry gets |
+|-------|-------------|------------|
+| **Ideas** | A topic is captured — manually or from analytics | slug, title, description, source |
+| **Planned** | Topic is committed to — target keywords are set | target keywords |
+| **Drafting** | Blog post is scaffolded, GitHub issue created | blog directory, issue number |
+| **Review** | Post is written and under review | (manual stage) |
+| **Published** | Post is live on the site | publish date, issue closed |
+
+### Entry Fields
+
+Each calendar entry tracks:
+
+- **slug** — URL-safe identifier (e.g., `scsi-over-wifi-raspberry-pi-bridge`)
+- **title** — human-readable post title
+- **description** — one-line SEO description
+- **targetKeywords** — SEO keywords (set during planning)
+- **datePublished** — ISO date when published
+- **issueNumber** — linked GitHub issue
+- **source** — `manual` (human idea) or `analytics` (data-driven suggestion)
+
+## Skills
+
+The editorial workflow is managed through composable Claude Code skills — one per action, like UNIX tools.
+
+### Content lifecycle
+
+| Skill | Purpose |
+|-------|---------|
+| `/editorial-add "Title"` | Add an idea to the calendar |
+| `/editorial-plan slug "kw1, kw2"` | Move to Planned, set target keywords |
+| `/editorial-draft slug` | Scaffold blog post, create GitHub issue, move to Drafting |
+| `/editorial-publish slug` | Mark as Published, close GitHub issue |
+
+### Analytics integration
+
+| Skill | Purpose |
+|-------|---------|
+| `/editorial-suggest` | Pull Search Console data, surface content opportunities |
+| `/editorial-performance` | Show metrics for published posts, flag underperformers |
+
+### Status and help
+
+| Skill | Purpose |
+|-------|---------|
+| `/editorial-review` | Show calendar entries across all stages |
+| `/editorial-help` | Show the workflow diagram and calendar summary |
+
+## Typical Workflow
+
+### Adding content manually
+
+```
+/editorial-add "SCSI Protocol Deep Dive"
+/editorial-plan scsi-protocol-deep-dive "SCSI protocol, vintage hardware, SCSI commands"
+/editorial-draft scsi-protocol-deep-dive
+# ... write the post ...
+/editorial-publish scsi-protocol-deep-dive
+```
+
+### Adding content from analytics
+
+```
+/editorial-suggest
+# Review suggestions with evidence (impressions, position, CTR)
+# Accept suggestions — they're added to Ideas with source: analytics
+/editorial-plan selected-slug "keywords"
+# ... continue as above ...
+```
+
+### Checking performance
+
+```
+/editorial-performance
+# See metrics for all published posts
+# Posts needing attention are flagged with specific recommendations
+```
+
+## Analytics Integration
+
+The editorial calendar integrates with the analytics pipeline (Umami, GA4, Google Search Console):
+
+- **`/editorial-suggest`** queries Search Console for striking-distance queries (position 5-20) and CTR opportunities (high impressions, low clicks). Suggestions include specific evidence so you can make informed decisions about what to write.
+
+- **`/editorial-performance`** matches each published post to its metrics across all data sources and surfaces recommendations from the analytics engine (rewrite titles, boost rankings, investigate bounce rates, add CTAs).
+
+This creates a virtuous cycle: measure what's working, identify gaps, plan new content, publish, measure again.
+
+## File Layout
+
+```
+docs/editorial-calendar.md              # The calendar itself (markdown tables)
+scripts/lib/editorial/
+  types.ts                               # Stage definitions, CalendarEntry type
+  calendar.ts                            # Markdown parser/writer, mutations
+  scaffold.ts                            # Blog post directory/frontmatter generation
+  suggest.ts                             # Analytics integration (suggestions + performance)
+  index.ts                               # Barrel export
+.claude/skills/editorial-*/SKILL.md      # One skill per action (8 total)
+```
+
+## Calendar Format
+
+The calendar file (`docs/editorial-calendar.md`) uses markdown tables. Non-published stages:
+
+```markdown
+## Ideas
+
+| Slug | Title | Description | Keywords | Source |
+|------|-------|-------------|----------|--------|
+| my-idea | My Post Idea | A post about things | | manual |
+```
+
+Published stage has extra columns:
+
+```markdown
+## Published
+
+| Slug | Title | Description | Keywords | Source | Published | Issue |
+|------|-------|-------------|----------|--------|-----------|-------|
+| my-post | My Post | About things | kw1, kw2 | analytics | 2026-04-15 | #43 |
+```
+
+Stages with entries in Drafting or Review include an Issue column when any entry has a linked issue.

--- a/DEVELOPMENT-NOTES.md
+++ b/DEVELOPMENT-NOTES.md
@@ -4,6 +4,39 @@ Session journal for audiocontrol.org. Each entry records what was tried, what wo
 
 ---
 
+## 2026-04-16: Editorial Calendar — Analytics Wiring & Documentation
+### Feature: editorial-calendar
+### Worktree: audiocontrol.org-editorial-calendar
+
+**Goal:** Wire editorial calendar to the newly-merged analytics pipeline, add CONTENT-CALENDAR.md documentation, create PR.
+
+**Accomplished:**
+- Rewrote `suggest.ts` from stub functions to live analytics integration (Umami, GA4, Search Console)
+- `getContentSuggestions()` extracts striking-distance and CTR opportunities from Search Console, deduplicates against existing calendar entries
+- `getPostPerformance()` matches published posts to metrics across all data sources, surfaces recommendations
+- Updated `/editorial-suggest` and `/editorial-performance` skills to remove dependency warnings
+- Created CONTENT-CALENDAR.md documenting the full workflow, skills reference, and file layout
+- Added content calendar reference to top-level README
+- Created PR oletizi/audiocontrol.org#46
+
+**Didn't Work:**
+- N/A
+
+**Course Corrections:**
+- None this session
+
+**Quantitative:**
+- Messages: ~10
+- Commits: 4
+- Corrections: 0
+- Files changed: 7
+
+**Insights:**
+- Wiring to an existing analytics pipeline was straightforward — the types and interfaces aligned naturally since suggest.ts was designed with the analytics dependency in mind
+- Writing documentation (CONTENT-CALENDAR.md) after the full system exists produces clearer docs than writing during implementation — the workflow is settled and the edge cases are known
+
+---
+
 ## 2026-04-16: Automated Analytics — Full Implementation
 ### Feature: automated-analytics
 ### Worktree: audiocontrol.org-automated-analytics

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ npm run preview        # Preview production build
 npm test               # Run unit tests (vitest)
 ```
 
+## Content Calendar
+
+Editorial calendar tracking blog posts from idea through publication, with analytics-driven topic suggestions and performance tracking. Managed via `/editorial-*` Claude Code skills.
+
+See [CONTENT-CALENDAR.md](./CONTENT-CALENDAR.md) for the workflow, skills reference, and file layout.
+
 ## Analytics
 
 Automated analytics pipeline pulling from Umami Cloud, GA4, and Google Search Console. Run `/analytics` in Claude Code or `tsx scripts/analytics-report.ts` from the CLI.

--- a/docs/1.0/001-IN-PROGRESS/editorial-calendar/README.md
+++ b/docs/1.0/001-IN-PROGRESS/editorial-calendar/README.md
@@ -15,7 +15,7 @@ Structured editorial calendar that tracks content through its lifecycle (idea th
 |-------|-------------|--------|
 | 1 | Calendar Structure & Basic Management | Complete |
 | 2 | Post Scaffolding | Complete |
-| 3 | Analytics Integration | Complete (blocked on oletizi/audiocontrol.org#30 for live data) |
+| 3 | Analytics Integration | Complete |
 
 ## Dependencies
 

--- a/docs/1.0/001-IN-PROGRESS/editorial-calendar/workplan.md
+++ b/docs/1.0/001-IN-PROGRESS/editorial-calendar/workplan.md
@@ -86,7 +86,7 @@
 - [x] Implement suggest.ts library for analytics integration
 - [x] Track analytics-suggested vs manually added entries in the calendar
 
-**Note:** Skills and library are implemented. Analytics functions throw descriptive errors until the automated-analytics feature (oletizi/audiocontrol.org#30) provides the data pipeline. The `source` field on CalendarEntry distinguishes `analytics` vs `manual` entries.
+**Note:** Analytics integration is live — `suggest.ts` calls the analytics pipeline (Umami, GA4, Search Console) via `scripts/lib/analytics/`. The `source` field on CalendarEntry distinguishes `analytics` vs `manual` entries.
 
 **Acceptance Criteria:**
 - `/editorial-suggest` shows content opportunities derived from analytics data

--- a/scripts/lib/editorial/suggest.ts
+++ b/scripts/lib/editorial/suggest.ts
@@ -1,16 +1,26 @@
 /**
  * Analytics integration for the editorial calendar.
  *
- * This module bridges the editorial calendar with the automated-analytics
- * feature (oletizi/audiocontrol.org#30). It parses analytics reports to
- * surface content opportunities and track published post performance.
- *
- * ## Dependency
- *
- * Requires the automated-analytics feature to be implemented. Until then,
- * functions throw descriptive errors pointing to the missing dependency.
- * See: https://github.com/oletizi/audiocontrol.org/issues/30
+ * Bridges the editorial calendar with the automated-analytics pipeline
+ * to surface content opportunities and track published post performance.
  */
+
+import {
+  loadApiKey,
+  getBaseUrl,
+  getWebsiteId,
+  buildContentScorecard,
+  buildGa4Scorecard,
+  buildSearchPerformance,
+  buildContentFunnel,
+  generateRecommendations,
+} from '../analytics/index.js';
+import type {
+  AnalyticsReport,
+  DateRange,
+  Recommendation,
+} from '../analytics/index.js';
+import type { CalendarEntry } from './types.js';
 
 /** A content opportunity identified from analytics data. */
 export interface ContentSuggestion {
@@ -45,34 +55,171 @@ export interface PostPerformance {
   recommendations: string[];
 }
 
+function computeDateRange(days: number): DateRange {
+  const end = new Date();
+  const start = new Date(end);
+  start.setDate(start.getDate() - days + 1);
+  return {
+    startDate: start.toISOString().split('T')[0],
+    endDate: end.toISOString().split('T')[0],
+  };
+}
+
+/** Fetch the full analytics report. */
+async function fetchReport(days: number): Promise<AnalyticsReport> {
+  const apiKey = loadApiKey();
+  const baseUrl = getBaseUrl();
+  const websiteId = getWebsiteId();
+  const dateRange = computeDateRange(days);
+
+  const [scorecard, ga4Scorecard, search] = await Promise.all([
+    buildContentScorecard(apiKey, baseUrl, websiteId, dateRange),
+    buildGa4Scorecard(dateRange).catch(() => null),
+    buildSearchPerformance(dateRange),
+  ]);
+
+  const funnel = buildContentFunnel(scorecard, ga4Scorecard);
+
+  const report: AnalyticsReport = {
+    scorecard,
+    ga4Scorecard,
+    search,
+    funnel,
+    recommendations: [],
+  };
+  report.recommendations = generateRecommendations(report);
+
+  return report;
+}
+
 /**
- * Parse analytics data and return content suggestions.
+ * Get content suggestions from analytics data.
  *
  * Identifies:
- * - High-impression queries with no matching content
- * - Striking-distance queries (positions 8-20) that could rank higher
- * - Content gaps where competitors rank but we don't
+ * - Striking-distance queries (positions 5-20) that could rank higher with new/updated content
+ * - High-impression/low-CTR queries that need better targeting
+ * - Queries with no matching calendar entry (content gaps)
  */
-export function getContentSuggestions(): ContentSuggestion[] {
-  throw new Error(
-    'Analytics integration not yet available. ' +
-      'The automated-analytics feature (oletizi/audiocontrol.org#30) must be implemented first. ' +
-      'See Phase 1 (GA4 pipeline) and Phase 2 (Search Console) issues: #36, #37.',
-  );
+export async function getContentSuggestions(
+  existingEntries: CalendarEntry[],
+  days: number = 30,
+): Promise<ContentSuggestion[]> {
+  const report = await fetchReport(days);
+  const suggestions: ContentSuggestion[] = [];
+  const existingSlugs = new Set(existingEntries.map((e) => e.slug));
+
+  // Striking-distance queries — new content opportunities
+  for (const q of report.search.strikingDistance) {
+    const pagePath = q.page.replace('https://audiocontrol.org', '');
+    const slug = pagePath.replace(/^\/blog\//, '').replace(/\/$/, '');
+
+    // Skip if this slug is already tracked in the calendar
+    if (existingSlugs.has(slug)) continue;
+
+    suggestions.push({
+      topic: q.query,
+      rationale: `Striking distance — position ${q.position.toFixed(1)} with ${q.impressions} impressions. New or expanded content could push this to page 1.`,
+      evidence: {
+        query: q.query,
+        impressions: q.impressions,
+        position: q.position,
+      },
+    });
+  }
+
+  // CTR opportunities — existing pages that need title/description improvement
+  for (const opp of report.search.ctrOpportunities) {
+    suggestions.push({
+      topic: opp.query,
+      rationale: `Low CTR — ${opp.impressions} impressions but only ${(opp.ctr * 100).toFixed(1)}% CTR at position ${opp.position.toFixed(1)}. Title/description may need rewriting.`,
+      evidence: {
+        query: opp.query,
+        impressions: opp.impressions,
+        position: opp.position,
+        ctr: opp.ctr,
+      },
+    });
+  }
+
+  // Deduplicate by query
+  const seen = new Set<string>();
+  return suggestions.filter((s) => {
+    if (!s.evidence.query) return true;
+    if (seen.has(s.evidence.query)) return false;
+    seen.add(s.evidence.query);
+    return true;
+  });
 }
 
 /**
  * Get performance metrics for published posts.
  *
- * Flags underperformers based on:
- * - Declining traffic trend
- * - High impressions but low CTR (title/description needs improvement)
- * - Dropping average position (content freshness issue)
+ * Matches published calendar entries to analytics data and flags
+ * underperformers with specific recommendations.
  */
-export function getPostPerformance(): PostPerformance[] {
-  throw new Error(
-    'Analytics integration not yet available. ' +
-      'The automated-analytics feature (oletizi/audiocontrol.org#30) must be implemented first. ' +
-      'See Phase 3 (Actionable Report) issue: #38.',
-  );
+export async function getPostPerformance(
+  publishedEntries: CalendarEntry[],
+  days: number = 30,
+): Promise<PostPerformance[]> {
+  const report = await fetchReport(days);
+  const results: PostPerformance[] = [];
+
+  // Index recommendations by page path for lookup
+  const recsByPage = new Map<string, Recommendation[]>();
+  for (const rec of report.recommendations) {
+    const existing = recsByPage.get(rec.page) ?? [];
+    existing.push(rec);
+    recsByPage.set(rec.page, existing);
+  }
+
+  for (const entry of publishedEntries) {
+    const blogPath = `/blog/${entry.slug}/`;
+
+    // Find Umami metrics
+    const umamiPage = report.scorecard.pages.find(
+      (p) => p.pagePath === blogPath,
+    );
+
+    // Find GA4 metrics
+    const ga4Page = report.ga4Scorecard?.pages.find(
+      (p) => p.current.pagePath === blogPath,
+    );
+
+    // Find search metrics (aggregate across queries for this page)
+    const searchRows = report.search.topQueries.filter((q) =>
+      q.page.endsWith(blogPath) || q.page.endsWith(entry.slug),
+    );
+    const totalImpressions = searchRows.reduce((s, r) => s + r.impressions, 0);
+    const totalClicks = searchRows.reduce((s, r) => s + r.clicks, 0);
+    const avgPosition = searchRows.length > 0
+      ? searchRows.reduce((s, r) => s + r.position, 0) / searchRows.length
+      : undefined;
+
+    // Collect recommendations for this page
+    const pageRecs = recsByPage.get(blogPath) ?? [];
+    const needsUpdate = pageRecs.length > 0;
+
+    results.push({
+      slug: entry.slug,
+      title: entry.title,
+      metrics: {
+        pageviews: umamiPage?.pageviews ?? ga4Page?.current.screenPageViews,
+        sessions: umamiPage?.visits,
+        avgPosition,
+        impressions: totalImpressions || undefined,
+        clicks: totalClicks || undefined,
+        ctr: totalImpressions > 0 ? totalClicks / totalImpressions : undefined,
+      },
+      needsUpdate,
+      recommendations: pageRecs.map((r) => r.detail),
+    });
+  }
+
+  // Sort: posts needing update first, then by pageviews descending
+  results.sort((a, b) => {
+    if (a.needsUpdate !== b.needsUpdate) return a.needsUpdate ? -1 : 1;
+    return (b.metrics.pageviews ?? 0) - (a.metrics.pageviews ?? 0);
+  });
+
+  return results;
 }


### PR DESCRIPTION
## Summary

- Wire `suggest.ts` to the live analytics pipeline (Umami, GA4, Search Console) — replaces stub functions that previously threw
- Update `/editorial-suggest` and `/editorial-performance` skills to reflect live integration
- Add `CONTENT-CALENDAR.md` documenting the editorial workflow, skills, and file layout
- Add content calendar reference to top-level README

## Test plan

- [x] `npm run build` succeeds
- [x] Calendar parser round-trips correctly
- [ ] `/editorial-suggest` returns suggestions from live Search Console data
- [ ] `/editorial-performance` returns metrics for published posts
- [ ] `/editorial-help` shows workflow and calendar status
- [ ] CONTENT-CALENDAR.md accurately describes the system

Closes #42. Related: #29 (parent), #30 (analytics dependency).
