### PR TITLE
Phase 6: YouTube videos + tools as first-class calendar entries + cross-link audit

### DIFF
--- a/.claude/skills/editorial-add/SKILL.md
+++ b/.claude/skills/editorial-add/SKILL.md
@@ -14,6 +14,8 @@ The user provides a title (and optionally a description) as the skill argument. 
 - `/editorial-add "SCSI Protocol Deep Dive"`
 - `/editorial-add "SCSI Protocol Deep Dive" "A technical walkthrough of the SCSI protocol for vintage hardware"`
 
+After title/description, prompt for **content type** — `blog` (default) or `youtube`. For YouTube entries, also prompt for the video URL if the user already has it; leave `contentUrl` unset if the video hasn't been published yet (URL is required at publish time).
+
 ## Steps
 
 1. **Read the calendar**: Read `docs/editorial-calendar.md`
@@ -24,6 +26,8 @@ The user provides a title (and optionally a description) as the skill argument. 
    - Title (from user)
    - Description (from user, or empty)
    - Keywords (empty — set later via `/editorial-plan`)
+   - Content type (if not `blog`; the writer adds a Type column when any entry in the stage has a non-default type)
+   - Content URL (for YouTube entries with a known URL; otherwise omit)
    - Source: `manual`
 5. **Write the calendar**: Write the updated `docs/editorial-calendar.md`
 6. **Report**: Confirm the entry was added and show its slug

--- a/.claude/skills/editorial-add/SKILL.md
+++ b/.claude/skills/editorial-add/SKILL.md
@@ -14,7 +14,13 @@ The user provides a title (and optionally a description) as the skill argument. 
 - `/editorial-add "SCSI Protocol Deep Dive"`
 - `/editorial-add "SCSI Protocol Deep Dive" "A technical walkthrough of the SCSI protocol for vintage hardware"`
 
-After title/description, prompt for **content type** — `blog` (default) or `youtube`. For YouTube entries, also prompt for the video URL if the user already has it; leave `contentUrl` unset if the video hasn't been published yet (URL is required at publish time).
+After title/description, prompt for **content type** — one of:
+
+- `blog` (default) — lives in this repo at `src/pages/blog/<slug>/`
+- `youtube` — video hosted on YouTube; prompt for the video URL if known
+- `tool` — standalone tool or app on audiocontrol.org (e.g. an editor page); prompt for the tool URL
+
+For `youtube` and `tool` entries, if the content is already published the URL should be captured now. If the content is still planned (not yet live), `contentUrl` stays unset and must be filled in before `/editorial-publish` will advance the entry.
 
 ## Steps
 
@@ -27,7 +33,7 @@ After title/description, prompt for **content type** — `blog` (default) or `yo
    - Description (from user, or empty)
    - Keywords (empty — set later via `/editorial-plan`)
    - Content type (if not `blog`; the writer adds a Type column when any entry in the stage has a non-default type)
-   - Content URL (for YouTube entries with a known URL; otherwise omit)
+   - Content URL (for `youtube` and `tool` entries with a known URL; otherwise omit)
    - Source: `manual`
 5. **Write the calendar**: Write the updated `docs/editorial-calendar.md`
 6. **Report**: Confirm the entry was added and show its slug

--- a/.claude/skills/editorial-cross-link-review/SKILL.md
+++ b/.claude/skills/editorial-cross-link-review/SKILL.md
@@ -49,4 +49,4 @@ Group sections exactly as above. Omit any section that has no items. If everythi
 - **Don't fail the whole audit on one bad fetch**: if the YouTube API errors for one video, record the error against that entry and move on. Users will want to see partial results.
 - **Unresolved outbound links** (a YouTube URL in a blog post that doesn't match any known video calendar entry) should prompt the user to consider adding it as a calendar entry — that's the main way Phase 6 expects the calendar to grow.
 - **Blog entries without markdown files** should still report (as errors) — missing markdown usually means the blog post is tracked in the calendar but not yet written.
-- If `~/.config/audiocontrol/youtube.json` is missing, the skill throws with setup instructions from `scripts/lib/youtube/config.ts`. No silent degradation.
+- If `~/.config/audiocontrol/youtube-key.txt` is missing, the skill throws with setup instructions from `scripts/lib/youtube/config.ts`. No silent degradation.

--- a/.claude/skills/editorial-cross-link-review/SKILL.md
+++ b/.claude/skills/editorial-cross-link-review/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: editorial-cross-link-review
+description: "Audit bidirectional linking between blog posts and YouTube videos; flag missing reciprocal links."
+user_invocable: true
+---
+
+# Editorial Cross-link Review
+
+For each Published calendar entry, check what it links to and whether those links reciprocate. A healthy state: every blog post that embeds a video's URL also has that video's description linking back to the post, and vice versa. Gaps mean readers/viewers can't hop between the two.
+
+## Steps
+
+1. **Read the calendar** via `readCalendar(process.cwd())`.
+2. **Build a blog-markdown loader**: given a slug, read `src/pages/blog/<slug>/index.md` and return its content. Return `null` on read errors.
+3. **Build a video-description loader**: given a `contentUrl`, call `getVideoMetadata(url)` from `scripts/lib/youtube/client.ts` and return the `description` field. Catch and swallow errors — return `null` for that entry instead, and let the audit record it.
+4. **Run the audit**: `auditCrossLinks({ calendar, fetchBlogMarkdown, fetchVideoDescription })` from `scripts/lib/editorial/crosslinks.ts`.
+5. **Report** the results using the format below.
+
+## Report Format
+
+```
+Cross-link Audit (N Published entries)
+
+✓ Reciprocated (both sides link):
+  claude-vs-codex-claude-perspective ↔ s330-editor-demo-video
+
+⚠ Blog links to video, but video doesn't link back:
+  s330-post → s330-video
+    (missing in video description)
+
+⚠ Video links to blog, but blog doesn't link back:
+  s330-video → s330-post
+    (missing in src/pages/blog/s330-post/index.md)
+
+⚠ Outbound link does not resolve to any calendar entry:
+  s330-post links to https://youtu.be/UNKNOWN_VIDEO_ID
+    (is this a video you want to add to the calendar?)
+
+Errors:
+  - video-without-url: YouTube entry has no contentUrl
+  - s330-fetch-fail: fetching description for s330-fetch-fail: YouTube API error 403
+```
+
+Group sections exactly as above. Omit any section that has no items. If everything reciprocates, say "All cross-links reciprocate." and stop.
+
+## Important
+
+- **Read-only** — do not modify `docs/editorial-calendar.md` or any blog markdown files.
+- **Don't fail the whole audit on one bad fetch**: if the YouTube API errors for one video, record the error against that entry and move on. Users will want to see partial results.
+- **Unresolved outbound links** (a YouTube URL in a blog post that doesn't match any known video calendar entry) should prompt the user to consider adding it as a calendar entry — that's the main way Phase 6 expects the calendar to grow.
+- **Blog entries without markdown files** should still report (as errors) — missing markdown usually means the blog post is tracked in the calendar but not yet written.
+- If `~/.config/audiocontrol/youtube.json` is missing, the skill throws with setup instructions from `scripts/lib/youtube/config.ts`. No silent degradation.

--- a/.claude/skills/editorial-draft/SKILL.md
+++ b/.claude/skills/editorial-draft/SKILL.md
@@ -6,7 +6,7 @@ user_invocable: true
 
 # Editorial Draft
 
-Move a Planned calendar entry to Drafting. For **blog** entries: creates the blog post directory, index.md with frontmatter, a GitHub tracking issue, and moves the entry. For **youtube** entries: creates a GitHub tracking issue only (no directory — the video lives on YouTube) and moves the entry.
+Move a Planned calendar entry to Drafting. For **blog** entries: creates the blog post directory, index.md with frontmatter, a GitHub tracking issue, and moves the entry. For **youtube** and **tool** entries: creates a GitHub tracking issue only (no directory — the content lives outside the repo) and moves the entry.
 
 ## Input
 
@@ -19,9 +19,9 @@ The user provides the slug of a Planned entry. Example:
 2. **Find the entry**: Look for the slug in the calendar
    - If not found: report error and list available Planned entries
    - If found but not in Planned stage: report its current stage and stop
-3. **Branch on content type** (use `effectiveContentType(entry)` — defaults to `'blog'`):
+3. **Branch on content type** (use `hasRepoContent(effectiveContentType(entry))` — true only for `blog`):
 
-### If contentType is `blog`
+### If the entry has repo content (i.e. contentType is `blog`)
 
 4. **Check for existing post**: Verify `src/pages/blog/<slug>/index.md` does not already exist
    - If it exists: report error and stop
@@ -43,12 +43,12 @@ The user provides the slug of a Planned entry. Example:
    - Title: `[blog post] <entry title>`
    - Body: Description, target keywords, and acceptance criteria (draft, review, publish)
 
-### If contentType is `youtube`
+### Else (contentType is `youtube` or `tool`)
 
-4. **Skip the directory scaffolding** — YouTube videos don't live in the repo.
+4. **Skip the directory scaffolding** — the content lives outside this repo.
 5. **Create GitHub issue**:
-   - Title: `[youtube] <entry title>`
-   - Body: Description, target keywords, topics (if any), acceptance criteria (film, edit, upload, publish — with link-back to blog posts if applicable)
+   - Title: `[<contentType>] <entry title>`
+   - Body: Description, target keywords, topics (if any), acceptance criteria appropriate to the type (e.g. youtube: film/edit/upload/publish with link-back to blog posts if applicable; tool: build/test/deploy/link-from-blog)
    - Mention that the contentUrl must be set on the calendar entry before `/editorial-publish` will advance it.
 
 ### Common final steps
@@ -65,4 +65,4 @@ The user provides the slug of a Planned entry. Example:
 - Use the Write tool to persist changes to `docs/editorial-calendar.md`
 - The author is always "Orion Letizi" unless the user specifies otherwise
 - Follow the frontmatter format exactly as shown in existing blog posts
-- For YouTube entries, do NOT create any files under `src/pages/blog/` — the only artifact is the GitHub issue
+- For `youtube` and `tool` entries, do NOT create any files under `src/pages/blog/` — the only artifact is the GitHub issue

--- a/.claude/skills/editorial-draft/SKILL.md
+++ b/.claude/skills/editorial-draft/SKILL.md
@@ -6,7 +6,7 @@ user_invocable: true
 
 # Editorial Draft
 
-Scaffold a blog post from a Planned calendar entry. Creates the blog post directory, index.md with frontmatter, a GitHub issue, and moves the entry to Drafting.
+Move a Planned calendar entry to Drafting. For **blog** entries: creates the blog post directory, index.md with frontmatter, a GitHub tracking issue, and moves the entry. For **youtube** entries: creates a GitHub tracking issue only (no directory — the video lives on YouTube) and moves the entry.
 
 ## Input
 
@@ -19,10 +19,14 @@ The user provides the slug of a Planned entry. Example:
 2. **Find the entry**: Look for the slug in the calendar
    - If not found: report error and list available Planned entries
    - If found but not in Planned stage: report its current stage and stop
-3. **Check for existing post**: Verify `src/pages/blog/<slug>/index.md` does not already exist
+3. **Branch on content type** (use `effectiveContentType(entry)` — defaults to `'blog'`):
+
+### If contentType is `blog`
+
+4. **Check for existing post**: Verify `src/pages/blog/<slug>/index.md` does not already exist
    - If it exists: report error and stop
-4. **Create blog post directory**: Create `src/pages/blog/<slug>/`
-5. **Create index.md**: Generate frontmatter following existing blog conventions:
+5. **Create blog post directory**: Create `src/pages/blog/<slug>/`
+6. **Create index.md**: Generate frontmatter following existing blog conventions:
    ```yaml
    ---
    layout: ../../../layouts/BlogLayout.astro
@@ -35,19 +39,30 @@ The user provides the slug of a Planned entry. Example:
    ---
    ```
    Then add an `# <title>` heading and a `<!-- Write your post here -->` placeholder.
-6. **Create GitHub issue**: Run `gh issue create` with:
+7. **Create GitHub issue**:
    - Title: `[blog post] <entry title>`
    - Body: Description, target keywords, and acceptance criteria (draft, review, publish)
-   - Label: (none required)
-7. **Update the calendar**:
+
+### If contentType is `youtube`
+
+4. **Skip the directory scaffolding** — YouTube videos don't live in the repo.
+5. **Create GitHub issue**:
+   - Title: `[youtube] <entry title>`
+   - Body: Description, target keywords, topics (if any), acceptance criteria (film, edit, upload, publish — with link-back to blog posts if applicable)
+   - Mention that the contentUrl must be set on the calendar entry before `/editorial-publish` will advance it.
+
+### Common final steps
+
+8. **Update the calendar**:
    - Move the entry from Planned to Drafting
    - Set the issue number from the created issue
    - Write the updated `docs/editorial-calendar.md`
-8. **Report**: Confirm what was created — file path, issue number, next step (`/editorial-publish`)
+9. **Report**: Confirm what was created — for blog: file path + issue; for youtube: issue only + reminder that publishing requires contentUrl. Next step: `/editorial-publish`.
 
 ## Important
 
-- Use the Write tool to create `src/pages/blog/<slug>/index.md`
+- Use the Write tool to create `src/pages/blog/<slug>/index.md` (blog entries only)
 - Use the Write tool to persist changes to `docs/editorial-calendar.md`
 - The author is always "Orion Letizi" unless the user specifies otherwise
 - Follow the frontmatter format exactly as shown in existing blog posts
+- For YouTube entries, do NOT create any files under `src/pages/blog/` — the only artifact is the GitHub issue

--- a/.claude/skills/editorial-help/SKILL.md
+++ b/.claude/skills/editorial-help/SKILL.md
@@ -38,7 +38,7 @@ Show the editorial content lifecycle and current calendar status. Do NOT modify 
 **YouTube integration skills (Phase 6):**
 - `/editorial-cross-link-review` — Audit bidirectional links between blog posts and YouTube videos; flag missing reciprocal links
 
-YouTube videos are first-class calendar entries — use `/editorial-add` with content type `youtube`. They go through the same five stages as blog posts, but `/editorial-draft` creates only a GitHub issue (no directory) and `/editorial-publish` requires a `contentUrl` (the YouTube video URL).
+YouTube videos and tools/apps on audiocontrol.org are first-class calendar entries — use `/editorial-add` with content type `youtube` or `tool`. They go through the same five stages as blog posts, but `/editorial-draft` creates only a GitHub issue (no directory) and `/editorial-publish` requires a `contentUrl` (the YouTube URL or canonical page URL).
 
 **Status skills:**
 - `/editorial-review` — Show calendar status across all stages

--- a/.claude/skills/editorial-help/SKILL.md
+++ b/.claude/skills/editorial-help/SKILL.md
@@ -32,8 +32,13 @@ Show the editorial content lifecycle and current calendar status. Do NOT modify 
 - `/editorial-social-review` — Matrix of published posts vs platforms (subreddit count for Reddit)
 
 **Reddit cross-posting skills (Phase 5):**
-- `/editorial-reddit-sync` — Pull recent submissions from Reddit API and upsert distribution records automatically
+- `/editorial-reddit-sync` — Pull recent submissions from Reddit API and upsert distribution records automatically (matches both blog posts AND YouTube entries by URL)
 - `/editorial-reddit-opportunities <slug>` — Show already-shared subreddits (don't duplicate) and unshared candidates with subscriber counts
+
+**YouTube integration skills (Phase 6):**
+- `/editorial-cross-link-review` — Audit bidirectional links between blog posts and YouTube videos; flag missing reciprocal links
+
+YouTube videos are first-class calendar entries — use `/editorial-add` with content type `youtube`. They go through the same five stages as blog posts, but `/editorial-draft` creates only a GitHub issue (no directory) and `/editorial-publish` requires a `contentUrl` (the YouTube video URL).
 
 **Status skills:**
 - `/editorial-review` — Show calendar status across all stages

--- a/.claude/skills/editorial-publish/SKILL.md
+++ b/.claude/skills/editorial-publish/SKILL.md
@@ -19,32 +19,32 @@ The user provides the slug of an entry to publish. Example:
 2. **Find the entry**: Look for the slug in the calendar
    - If not found: report error and list available non-Published entries
    - If already Published: report that it's already published and stop
-3. **Branch on content type** (via `effectiveContentType(entry)` — defaults to `'blog'`):
+3. **Branch on content type** (use `requiresContentUrl(effectiveContentType(entry))` — true for everything except `blog`):
 
 ### If contentType is `blog`
 
 4. **Verify the blog post exists**: Check that `src/pages/blog/<slug>/index.md` exists
    - If not: report error — the post must be written before publishing
 
-### If contentType is `youtube`
+### Else (contentType is `youtube` or `tool`)
 
-4. **Verify `contentUrl` is set**. This must be the YouTube video URL. If unset, prompt the user for it and persist it onto the entry. Refuse to publish a YouTube entry without a URL.
+4. **Verify `contentUrl` is set**. This is the YouTube video URL for videos, the tool's canonical page URL for tools. If unset, prompt the user for it and persist it onto the entry. Refuse to publish without a URL.
 
 ### Common final steps
 
 5. **Update the calendar**:
    - Move the entry to Published
    - Set `datePublished` to today's date (YYYY-MM-DD)
-   - For YouTube entries, ensure the `contentUrl` is persisted
+   - For non-blog entries, ensure the `contentUrl` is persisted
    - Write the updated `docs/editorial-calendar.md`
 6. **Close the GitHub issue** (if one is linked):
    - For blog: `gh issue close <n> --comment "Published: /blog/<slug>/"`
-   - For youtube: `gh issue close <n> --comment "Published: <contentUrl>"`
-7. **Report**: Confirm the entry was marked as Published, the date, whether the issue was closed, and — for YouTube entries — a reminder to run `/editorial-cross-link-review` to verify the blog posts referenced in the video description reciprocate.
+   - For non-blog: `gh issue close <n> --comment "Published: <contentUrl>"`
+7. **Report**: Confirm the entry was marked as Published, the date, whether the issue was closed, and — for `youtube` entries — a reminder to run `/editorial-cross-link-review` to verify the blog posts referenced in the video description reciprocate.
 
 ## Important
 
 - Use the Write tool to persist changes to `docs/editorial-calendar.md`
 - Preserve all existing entries — only update the target entry
 - The publish date is always today unless the user specifies a different date
-- YouTube entries without `contentUrl` cannot be published — the URL is the canonical identifier for the published content
+- Non-blog entries without `contentUrl` cannot be published — the URL is the canonical identifier for the published content

--- a/.claude/skills/editorial-publish/SKILL.md
+++ b/.claude/skills/editorial-publish/SKILL.md
@@ -19,18 +19,32 @@ The user provides the slug of an entry to publish. Example:
 2. **Find the entry**: Look for the slug in the calendar
    - If not found: report error and list available non-Published entries
    - If already Published: report that it's already published and stop
-3. **Verify the blog post exists**: Check that `src/pages/blog/<slug>/index.md` exists
+3. **Branch on content type** (via `effectiveContentType(entry)` — defaults to `'blog'`):
+
+### If contentType is `blog`
+
+4. **Verify the blog post exists**: Check that `src/pages/blog/<slug>/index.md` exists
    - If not: report error — the post must be written before publishing
-4. **Update the calendar**:
+
+### If contentType is `youtube`
+
+4. **Verify `contentUrl` is set**. This must be the YouTube video URL. If unset, prompt the user for it and persist it onto the entry. Refuse to publish a YouTube entry without a URL.
+
+### Common final steps
+
+5. **Update the calendar**:
    - Move the entry to Published
    - Set `datePublished` to today's date (YYYY-MM-DD)
+   - For YouTube entries, ensure the `contentUrl` is persisted
    - Write the updated `docs/editorial-calendar.md`
-5. **Close the GitHub issue** (if one is linked):
-   - Run: `gh issue close <issue-number> --comment "Published: /blog/<slug>/"`
-6. **Report**: Confirm the entry was marked as Published, the date, and whether the issue was closed
+6. **Close the GitHub issue** (if one is linked):
+   - For blog: `gh issue close <n> --comment "Published: /blog/<slug>/"`
+   - For youtube: `gh issue close <n> --comment "Published: <contentUrl>"`
+7. **Report**: Confirm the entry was marked as Published, the date, whether the issue was closed, and — for YouTube entries — a reminder to run `/editorial-cross-link-review` to verify the blog posts referenced in the video description reciprocate.
 
 ## Important
 
 - Use the Write tool to persist changes to `docs/editorial-calendar.md`
 - Preserve all existing entries — only update the target entry
 - The publish date is always today unless the user specifies a different date
+- YouTube entries without `contentUrl` cannot be published — the URL is the canonical identifier for the published content

--- a/.claude/skills/editorial-reddit-sync/SKILL.md
+++ b/.claude/skills/editorial-reddit-sync/SKILL.md
@@ -24,9 +24,12 @@ If the file is missing, the skill throws with a clear error telling the user how
 
 1. **Fetch submissions**: call `getUserSubmissions(undefined, 200)` from `scripts/lib/reddit/client.ts` — reads the username from config and returns up to 200 of the user's most recent submissions. No authentication step.
 3. **Read the calendar** via `readCalendar(process.cwd())`.
-4. **Match each submission to a blog post**: a submission matches a Published entry if its `url` field contains `audiocontrol.org/blog/<slug>/` or if its `selftext` links to that path. Extract the slug from the URL.
+4. **Match each submission to a Published calendar entry**:
+   - **Blog match**: submission `url` or `selftext` contains `audiocontrol.org/blog/<slug>/` where `<slug>` exists as a Published blog entry. Extract the slug from the URL.
+   - **YouTube match**: submission `url` is a YouTube URL (watch/shorts/youtu.be) whose video ID matches the `contentUrl` of a Published YouTube entry. Use `extractVideoId` from `scripts/lib/youtube/client.ts` to normalize both sides.
+   - A submission may match at most one entry. Prefer blog match if both somehow apply. Unmatched submissions are reported but not recorded.
 5. **Build DistributionRecord for each match**:
-   - `slug`: extracted slug
+   - `slug`: the matched entry's slug (blog slug, or YouTube entry slug)
    - `platform`: `reddit`
    - `channel`: the submission's `subreddit` field (already canonical `r/<name>`)
    - `url`: the submission's `permalink` (the reddit.com thread URL)

--- a/docs/1.0/001-IN-PROGRESS/editorial-calendar/README.md
+++ b/docs/1.0/001-IN-PROGRESS/editorial-calendar/README.md
@@ -19,6 +19,7 @@ Structured editorial calendar that tracks content through its lifecycle (idea th
 | 4 | Social Distribution Tracking | Complete |
 | 5 | Subreddit Tracking & Cross-posting Opportunities | Ready to ship |
 | 6 | YouTube as First-Class Content + Cross-link Audit | In Progress |
+| 7 | Tool Cross-link Audit | Pending (starts after Phase 6 merges) |
 
 ## Dependencies
 

--- a/docs/1.0/001-IN-PROGRESS/editorial-calendar/README.md
+++ b/docs/1.0/001-IN-PROGRESS/editorial-calendar/README.md
@@ -18,7 +18,7 @@ Structured editorial calendar that tracks content through its lifecycle (idea th
 | 3 | Analytics Integration | Complete |
 | 4 | Social Distribution Tracking | Complete |
 | 5 | Subreddit Tracking & Cross-posting Opportunities | Ready to ship |
-| 6 | YouTube as First-Class Content + Cross-link Audit | Pending (starts after Phase 5 merges) |
+| 6 | YouTube as First-Class Content + Cross-link Audit | In Progress |
 
 ## Dependencies
 

--- a/docs/1.0/001-IN-PROGRESS/editorial-calendar/prd.md
+++ b/docs/1.0/001-IN-PROGRESS/editorial-calendar/prd.md
@@ -36,10 +36,17 @@ Content creation for audiocontrol.org is ad hoc with no schedule, no procedure, 
 
 ## In Scope (Phase 6 addition)
 
-- **YouTube videos as first-class calendar entries**: videos go through the same Ideas → Planned → Drafting → Review → Published lifecycle as blog posts. `CalendarEntry` gains a `contentType` discriminator (`blog` | `youtube`) and a `contentUrl` for content that doesn't live at `/blog/<slug>/`
-- **YouTube metadata via Data API v3**: small client that fetches video title, description, and channel given a video ID or URL. Authenticated with a single API key in `~/.config/audiocontrol/youtube.json`. No OAuth — the key has read-only access to public data
-- **Cross-link audit**: a new skill `/editorial-cross-link-review` that verifies bidirectional linking between blog posts and YouTube videos. For each calendar entry, it extracts outbound links from the content (blog MD or YouTube description) and flags missing reciprocal links
+- **YouTube videos as first-class calendar entries**: videos go through the same Ideas → Planned → Drafting → Review → Published lifecycle as blog posts. `CalendarEntry` gains a `contentType` discriminator (`blog` | `youtube` | `tool`) and a `contentUrl` for content that doesn't live at `/blog/<slug>/`
+- **Tools as first-class calendar entries**: standalone apps/editors on audiocontrol.org (like the S-330 web editor) get the same treatment as YouTube videos — tracked by `contentUrl`, lifecycle identical, no repo scaffolding
+- **YouTube metadata via Data API v3**: small client that fetches video title, description, and channel given a video ID or URL. Authenticated with a single API key in `~/.config/audiocontrol/youtube-key.txt`. No OAuth — the key has read-only access to public data
+- **Cross-link audit (blog ↔ YouTube only)**: a new skill `/editorial-cross-link-review` that verifies bidirectional linking between blog posts and YouTube videos. For each calendar entry, it extracts outbound links from the content (blog MD or YouTube description) and flags missing reciprocal links. Tool entries are tracked but not audited — see Phase 7 below for that extension.
 - **Reddit sync improvement**: when a Reddit submission links to a YouTube URL that matches a known YouTube calendar entry, record it as a distribution of that video. Closes the gap observed during the first live `/editorial-reddit-sync` run (6 S-330 editor video shares that had nowhere to attach)
+
+## In Scope (Phase 7 addition)
+
+- **Cross-link audit for tool entries**: fetch the tool's page HTML, parse outbound links (YouTube URLs and audiocontrol.org URLs), and resolve them against the calendar. Extends `/editorial-cross-link-review` so a gap like "blog post X mentions the editor but doesn't link to it" or "editor page embeds video Y but Y's description doesn't link to editor" is detected automatically
+- **Generalized audiocontrol.org link resolution**: any audiocontrol.org URL (blog, tool, or future types) can be resolved to its calendar entry via a unified `contentUrl` index. Not limited to `/blog/<slug>/` paths
+- **Lightweight HTML extraction**: regex-based extraction of `<a href>` and bare URLs from static HTML, no DOM parser dependency
 
 ## Deferred Scope
 
@@ -74,6 +81,7 @@ Each editorial action is a separate Claude Code skill, composed like UNIX tools.
 | `/editorial-reddit-sync` | 5 | Pull user Reddit submissions via API, upsert DistributionRecords |
 | `/editorial-reddit-opportunities` | 5 | For a published post, list relevant subreddits not yet distributed to, enriched with live subreddit metadata |
 | `/editorial-cross-link-review` | 6 | Audit bidirectional linking between blog posts and YouTube videos, flag missing reciprocal links |
+| `/editorial-cross-link-review` (extended) | 7 | Same skill; Phase 7 adds tool-page analysis and generalized audiocontrol.org link resolution |
 
 ### Calendar Format
 

--- a/docs/1.0/001-IN-PROGRESS/editorial-calendar/workplan.md
+++ b/docs/1.0/001-IN-PROGRESS/editorial-calendar/workplan.md
@@ -16,6 +16,7 @@
 | Phase 4: Social Distribution Tracking | oletizi/audiocontrol.org#54 |
 | Phase 5: Subreddit Tracking & Cross-posting Opportunities | oletizi/audiocontrol.org#56 |
 | Phase 6: YouTube as First-Class Content + Cross-link Audit | oletizi/audiocontrol.org#57 |
+| Phase 7: Tool Cross-link Audit | oletizi/audiocontrol.org#59 |
 
 ## Files Affected
 
@@ -43,8 +44,9 @@
 - `docs/editorial-channels.json` — curated `topic → [subreddit]` map
 - `scripts/lib/youtube/config.ts` — YouTube API key loader (Phase 6)
 - `scripts/lib/youtube/client.ts` — YouTube Data API v3 client — fetch video metadata (Phase 6)
-- `scripts/lib/editorial/crosslinks.ts` — extract links from blog MD and YouTube descriptions, diff bidirectional coverage (Phase 6)
+- `scripts/lib/editorial/crosslinks.ts` — extract links from blog MD and YouTube descriptions, diff bidirectional coverage (Phase 6); extended in Phase 7 for tool-page analysis and generalized audiocontrol.org link resolution
 - `.claude/skills/editorial-cross-link-review/SKILL.md` — audit skill (Phase 6)
+- `scripts/lib/http/fetch-page.ts` — minimal HTML fetcher for tool pages (Phase 7)
 
 ## Implementation Phases
 
@@ -337,6 +339,77 @@ Quota: 10,000 units per day free. One `videos.list` call costs 1 unit. The cross
 - Should blog-post MD extraction handle embedded iframes (`<iframe src="youtube.com/embed/...">`) in addition to plain URLs? (Proposed: **yes** — capture all three forms: plain URL, short URL, iframe embed.)
 - Should cross-link audit report be generated as markdown in `docs/` for review, or streamed only to the skill output? (Proposed: **stream only** — audit is fast enough that we don't need to cache; keeping it out of `docs/` avoids churn on every run.)
 - Slug uniqueness: a blog post and a YouTube video on the same topic could collide. (Proposed: **keep global slug uniqueness** — if conflict, the user differentiates manually, e.g. `s330-crunch-post` vs `s330-crunch-video`.)
+
+### Phase 7: Tool Cross-link Audit
+
+**Deliverable:** Extend `/editorial-cross-link-review` so tool entries participate fully — the audit fetches each tool page's HTML, extracts outbound links, resolves them against the calendar's `contentUrl` index, and flags missing reciprocal links in both directions (blog→tool, tool→blog, tool→video, video→tool).
+
+**Motivation:** Phase 6 added `tool` as a valid content type but deliberately skipped it in the cross-link audit — tools don't have a fetch-able "description" field like YouTube videos, and they don't have a repo MD file like blog posts. Phase 7 closes that gap by fetching the tool's actual rendered HTML page from audiocontrol.org and parsing its outbound links.
+
+Without this, gaps like "the S-330 editor page embeds the drum-crunch video but the video description doesn't link back" or "the editor page doesn't link to the Feb 2026 blog update" can't be detected automatically — the operator has to notice them manually, which is exactly what Phase 6 was supposed to prevent.
+
+#### Skill design
+
+No new user-invocable skill. `/editorial-cross-link-review` is extended: when it encounters a tool entry, it fetches the page HTML, extracts links, and includes the results in the report alongside blog and video entries.
+
+#### Implementation
+
+**HTML fetching**
+
+- [ ] `scripts/lib/http/fetch-page.ts` — minimal `fetchHtml(url)` returning the response body as text. Sets a descriptive User-Agent (e.g. `audiocontrol.org-editorial-calendar/1.0 cross-link-audit`), follows redirects, throws on non-2xx. No auth — these are public pages
+- [ ] Timeout: 10s. Tool pages are small and live on the same Netlify deploy; anything slower than 10s means the page is broken
+- [ ] No caching layer in this phase — cross-link audit is fast enough that a repeat fetch is fine. If it becomes an issue later, add a response cache keyed on URL
+
+**Link extraction**
+
+- [ ] `extractLinksFromHtml(html): string[]` in `crosslinks.ts` — regex-based extraction of `href="..."` / `href='...'` attributes and bare `https?://` URLs from the body. Returns absolute URLs, resolving relative `href`s against a base if one is passed in
+- [ ] Skip anchor-only links (`#section`), mail links (`mailto:`), and obvious non-content URLs (feeds, robots.txt, sitemap)
+- [ ] Unit tests against fixture Astro-built HTML — representative samples saved under `test/fixtures/tool-page.html`
+
+**Generalized link resolution**
+
+- [ ] Build a unified `byContentUrl: Map<string, CalendarEntry>` index in `auditCrossLinks`: for each Published entry, compute its canonical URL — `audiocontrol.org/blog/<slug>/` for blog entries, `contentUrl` for YouTube/tool entries — and add it to the map. Normalize by stripping trailing slashes and case-insensitive hostname
+- [ ] Replace the current `extractBlogLinksFromDescription` callers' resolution logic with the unified index so tool URLs resolve from YouTube descriptions too (currently they're silently dropped)
+
+**Tool-entry audit branch**
+
+- [ ] In `auditCrossLinks`, when encountering a tool entry:
+  - Fetch `entry.contentUrl` via `fetchHtml`
+  - Extract links with `extractLinksFromHtml`
+  - For each extracted link, resolve against the unified `byContentUrl` index; record as `OutboundLink { resolvedSlug, resolved }`
+  - On fetch failure, record an error and move on (same per-entry-error pattern as the YouTube branch)
+- [ ] Remove the Phase 6 "tool entries are tracked but the audit doesn't analyze them" skip
+
+**Reciprocation rules**
+
+- [ ] Same second-pass logic — if blog X links to tool Y and Y doesn't link back, flag it in Y's `missingBacklinksTo`; same in the other direction
+- [ ] Remove the Phase 6 second-pass tool-skip now that tools do have outbound links
+
+**Skill update**
+
+- [ ] `/editorial-cross-link-review` skill doc updated to describe tool-page analysis and the fact that tool URLs are now resolvable targets from other entries' content
+
+**Tests**
+
+- [ ] `extractLinksFromHtml` against fixture HTML covering `<a href="...">`, bare URLs in text, relative hrefs (ignored or resolved), anchor-only ignored, `mailto:` ignored
+- [ ] Unified `byContentUrl` index resolves all three content types correctly
+- [ ] `auditCrossLinks` with a tool entry + mock `fetchHtml` returning fixture HTML — verifies outbound extraction and reciprocation
+- [ ] End-to-end fixture: a calendar with a blog entry linking to a tool, a tool page linking back (or not) — both reciprocation states tested
+
+**Acceptance Criteria**
+
+- `/editorial-cross-link-review` reports outbound links for tool entries
+- Tool pages that embed YouTube videos are flagged if the video description doesn't link back to the tool
+- Blog posts that link to a tool are flagged if the tool page doesn't link back to the post
+- Unified content-URL resolution works for all three content types — no silent drops of audiocontrol.org URLs in YouTube descriptions
+- Fetch failures for individual tool pages don't abort the whole audit; they're recorded per-entry
+- Existing Phase 6 tests still pass (no regressions)
+
+#### Open questions (resolve before coding)
+
+- Should the audit follow links inside tool pages recursively (e.g., the editor links to a docs page that links to a blog post)? (Proposed: **no** — single-hop only. Recursive fetching adds complexity and a crawler-like pattern we don't need right now.)
+- Should we cache fetched HTML during a single audit run to avoid re-fetching the same URL? (Proposed: **yes** — in-memory per-audit Map, invalidated each run. Cheap to implement, protects against audits getting slow when many entries reference the same tool.)
+- Do we need a way to exclude specific outbound links from the audit (e.g., social icons in the site footer)? (Proposed: **not initially** — if the audit surfaces noise later, add an `editorial-crosslink-ignore.json` file with URL patterns. For now, the report just shows what it finds and the user can ignore.)
 
 ## Verification Checklist
 

--- a/docs/1.0/001-IN-PROGRESS/editorial-calendar/workplan.md
+++ b/docs/1.0/001-IN-PROGRESS/editorial-calendar/workplan.md
@@ -278,40 +278,36 @@ No changes — `editorial-channels.json` stays topic-to-subreddit. A YouTube vid
 
 **Core data model + skill updates**
 
-- [ ] Extend `types.ts` with `contentType` and `contentUrl`
-- [ ] Update `calendar.ts` parser/writer for Type/URL columns
-- [ ] Update `/editorial-add` to prompt for content type
-- [ ] Update `/editorial-draft` to branch on content type (blog scaffolds directory; youtube creates issue only)
-- [ ] Update `/editorial-publish` to require `contentUrl` for YouTube entries
+- [x] Extend `types.ts` with `contentType` and `contentUrl` (+ `effectiveContentType`, `isContentType` helpers)
+- [x] Update `calendar.ts` parser/writer for Type/URL columns (optional, emitted only when any entry uses non-default values)
+- [x] Update `/editorial-add` to prompt for content type
+- [x] Update `/editorial-draft` to branch on content type (blog scaffolds directory; youtube creates issue only)
+- [x] Update `/editorial-publish` to require `contentUrl` for YouTube entries
 
 **YouTube client**
 
-- [ ] `scripts/lib/youtube/config.ts` — loads `~/.config/audiocontrol/youtube.json` (`{apiKey: "..."}`). Throws with setup instructions if missing
-- [ ] `scripts/lib/youtube/client.ts` — `getVideoMetadata(videoIdOrUrl): {id, title, description, channelTitle, channelId, publishedAt}` using `https://www.googleapis.com/youtube/v3/videos?part=snippet&id=<id>&key=<apiKey>`
-- [ ] Video ID extraction helper supporting `youtube.com/watch?v=<id>`, `youtu.be/<id>`, and `youtube.com/shorts/<id>`
-- [ ] Fixture-based tests — real API calls happen only from skills, not tests
+- [x] `scripts/lib/youtube/config.ts` — loads `~/.config/audiocontrol/youtube.json` (`{apiKey: "..."}`)
+- [x] `scripts/lib/youtube/client.ts` — `getVideoMetadata(videoIdOrUrl)` via `/youtube/v3/videos?part=snippet`
+- [x] `extractVideoId` helper supporting `watch?v=`, `youtu.be/`, `shorts/`, `embed/`, and bare IDs
 
 **Cross-link audit**
 
-- [ ] `scripts/lib/editorial/crosslinks.ts`:
-  - `extractYouTubeLinksFromMarkdown(md): string[]` — parses `youtube.com` and `youtu.be` URLs from a blog MD file
-  - `extractBlogLinksFromDescription(desc): string[]` — parses `audiocontrol.org/blog/<slug>/` URLs
-  - `auditCrossLinks(calendar, fetchDescription)` — returns per-entry reports: what the entry links to, which of those are known calendar entries, and which don't reciprocate
-- [ ] `/editorial-cross-link-review` skill — calls `auditCrossLinks`, passes a `fetchDescription` closure that uses `scripts/lib/youtube/client.ts`, prints the report grouped by gap type
+- [x] `scripts/lib/editorial/crosslinks.ts` — `extractYouTubeLinksFromMarkdown`, `extractBlogLinksFromDescription`, `slugFromBlogUrl`, `auditCrossLinks` with bidirectional gap detection
+- [x] `/editorial-cross-link-review` skill
 
 **Reddit sync improvement**
 
-- [ ] Update `/editorial-reddit-sync` to match submissions against `contentUrl` for YouTube entries in addition to `/blog/<slug>/` URLs for blog entries
-- [ ] Re-run the sync after Phase 6 ships to attribute the 6 pre-existing S-330 editor video shares once that video becomes a calendar entry
+- [x] Update `/editorial-reddit-sync` to match submissions against `contentUrl` for YouTube entries in addition to blog URLs
+- [ ] Re-run the sync after Phase 6 ships, once the S-330 editor video exists as a calendar entry, to attribute the 6 pre-existing shares
 
 **Tests**
 
-- [ ] `contentType` + `contentUrl` round-trip on stage tables
-- [ ] Backwards-compat parsing of legacy tables (no Type/URL columns)
-- [ ] `extractYouTubeLinksFromMarkdown` against realistic blog MD
-- [ ] `extractBlogLinksFromDescription` against realistic YouTube descriptions
-- [ ] `auditCrossLinks` with fixture calendar + fixture descriptions, verifies gap detection in both directions
-- [ ] YouTube client fixture tests (no live API calls from tests)
+- [x] `contentType` + `contentUrl` round-trip on stage tables
+- [x] Backwards-compat parsing of legacy tables (no Type/URL columns)
+- [x] `extractYouTubeLinksFromMarkdown` against realistic blog MD
+- [x] `extractBlogLinksFromDescription` against realistic YouTube descriptions
+- [x] `auditCrossLinks` with fixture calendar + fixture descriptions — verifies reciprocation, missing-backlink detection, and error handling in both directions
+- [x] `extractVideoId` fixture tests covering all supported URL forms
 
 **Acceptance Criteria**
 

--- a/docs/1.0/001-IN-PROGRESS/editorial-calendar/workplan.md
+++ b/docs/1.0/001-IN-PROGRESS/editorial-calendar/workplan.md
@@ -325,11 +325,10 @@ No changes — `editorial-channels.json` stays topic-to-subreddit. A YouTube vid
 2. Open or create a project (reuse the one with the GA4 service account if you like)
 3. Enable the **YouTube Data API v3** under APIs & Services → Library
 4. Under Credentials, create an **API key**. Restrict it to the YouTube Data API v3 for hygiene
-5. Save:
-   ```json
-   { "apiKey": "AIza..." }
+5. Save the key as a single line at `~/.config/audiocontrol/youtube-key.txt` (matches the project's existing `flux-key.txt`, `openai-key.txt` convention):
+   ```bash
+   echo "AIza..." > ~/.config/audiocontrol/youtube-key.txt
    ```
-   at `~/.config/audiocontrol/youtube.json`
 
 Quota: 10,000 units per day free. One `videos.list` call costs 1 unit. The cross-link audit reads at most one video per calendar YouTube entry — we won't come close to the limit.
 

--- a/docs/editorial-calendar.md
+++ b/docs/editorial-calendar.md
@@ -29,6 +29,7 @@
 | claude-vs-codex-codex-perspective | What Happened When We Asked Claude and Codex to Build the Same Feature | We asked two AI coding agents to implement the same draggable zone editing feature for the Akai S3000XL editor. The most useful comparison wasn't about code quality -- it was about failure modes. |  |  | blog |  | manual | 2026-04-13 |  |
 | what-2400-session-taught-us-about-agent-workflow | Instructions Are Not Enough: What 2,400 Sessions Taught Us About AI Agent Workflow | Telling an AI agent what to do is easy. Getting it to reliably follow process requires something structural — skills, session journals, and correction-driven guardrails. |  |  | blog |  | manual | 2026-04-17 |  |
 | s330-drum-crunch-video | Vintage 12-bit Sampler Drum Sounds for Cheap | Vintage 12-bit sampler crunch for drums using a ~$200 Roland S-330 plus the free web editor — turn any drum hits into dozens of crunchy kits. |  | samplers, vintage-hardware, roland, home-studio | youtube | https://youtu.be/jWgCQDdsyrw | manual | 2026-03-03 |  |
+| s330-web-editor | Roland S-330 Web Editor | Free open-source web editor for the Roland S-330 12-bit sampler — no signup, no cloud, modern workflow for vintage hardware. |  | samplers, vintage-hardware, roland, home-studio | tool | https://audiocontrol.org/roland/s330/editor | manual | 2025-01-15 |  |
 
 ## Distribution
 
@@ -40,3 +41,5 @@
 | s330-drum-crunch-video | reddit | https://www.reddit.com/r/Samplers/comments/1rjyrac/roland_s330_12bit_crunch_for_drums_cheap/ | 2026-03-03 | r/Samplers | Roland S-330 12-Bit Crunch for Drums, Cheap |
 | s330-drum-crunch-video | reddit | https://www.reddit.com/r/synthesizers/comments/1rjyuuf/roland_s330_12bit_crunch_for_drums_cheap/ | 2026-03-03 | r/synthesizers | Roland S-330 12-Bit Crunch for Drums, Cheap |
 | s330-drum-crunch-video | reddit | https://www.reddit.com/r/Roland/comments/1rjyssb/roland_s330_12bit_crunch_for_drums_cheap/ | 2026-03-03 | r/Roland | Roland S-330 12-Bit Crunch for Drums, Cheap |
+| s330-web-editor | reddit | https://www.reddit.com/r/Samplers/comments/1qxov76/web_editor_for_roland_s330_12bit_samplerlooking/ | 2026-02-06 | r/Samplers | Web Editor for Roland S-330 12-bit Sampler — looking for feedback |
+| s330-web-editor | reddit | https://www.reddit.com/r/synthesizers/comments/1qxp6ih/web_editor_for_roland_s330_12bit_samplerlooking/ | 2026-02-06 | r/synthesizers | Web Editor for Roland S-330 12-bit Sampler — looking for feedback |

--- a/docs/editorial-calendar.md
+++ b/docs/editorial-calendar.md
@@ -18,16 +18,17 @@
 
 ## Published
 
-| Slug | Title | Description | Keywords | Source | Published | Issue |
-|------|------|------|------|------|------|------|
-| free-roland-s330-sampler-editor | A Free, Open Source Web Editor for the Roland S-330 Sampler | A guide to the Roland S-330 sampler and the open-source web editor for modern workflows. |  | manual | 2025-01-15 |  |
-| roland-s-series-samplers | The Roland S-Series Samplers: A Complete Guide to the S-330, S-550, S-770, and W-30 | A comprehensive guide to Roland's S-series sampler family — from the affordable S-330 to the flagship S-770, including the W-30 workstation, original accessories, and modern editing tools. |  | manual | 2025-02-15 |  |
-| roland-s330-sampler-editor-feb-2026-update | What's New in the Roland S-330 Web Editor: February 2026 | Real-time hardware sync, integrated video capture, debug tools, and quality-of-life improvements for the free S-330 sampler editor. |  | manual | 2026-02-09 |  |
-| reverse-engineering-akai-s3000xl-midi-over-scsi | Reverse-Engineering the Akai S3000XL MIDI-over-SCSI Protocol: An Odyssey | How a failed attempt to run Akai's MESA II in a Mac OS 9 emulator led us through 38 disproven theories in five days of intense debugging, and ultimately to a standalone 68k emulator that cracked the protocol in four hours. |  | manual | 2026-04-07 |  |
-| scsi-over-wifi-raspberry-pi-bridge | SCSI Over WiFi: Talking to Vintage Hardware from Your Phone | An open-source Raspberry Pi bridge that lets you send SCSI commands to vintage samplers and computers over HTTP and WebSocket -- no SCSI card required. |  | manual | 2026-04-07 |  |
-| claude-vs-codex-claude-perspective | Two AIs, One Feature: What Happens When Claude and Codex Build the Same Thing | Claude Code and Codex independently implemented the same draggable zone feature for the Akai S3000XL editor. The code was comparable. The sessions were not. |  | manual | 2026-04-13 |  |
-| claude-vs-codex-codex-perspective | What Happened When We Asked Claude and Codex to Build the Same Feature | We asked two AI coding agents to implement the same draggable zone editing feature for the Akai S3000XL editor. The most useful comparison wasn't about code quality -- it was about failure modes. |  | manual | 2026-04-13 |  |
-| what-2400-session-taught-us-about-agent-workflow | Instructions Are Not Enough: What 2,400 Sessions Taught Us About AI Agent Workflow | Telling an AI agent what to do is easy. Getting it to reliably follow process requires something structural — skills, session journals, and correction-driven guardrails. |  | manual | 2026-04-17 |  |
+| Slug | Title | Description | Keywords | Topics | Type | URL | Source | Published | Issue |
+|------|------|------|------|------|------|------|------|------|------|
+| free-roland-s330-sampler-editor | A Free, Open Source Web Editor for the Roland S-330 Sampler | A guide to the Roland S-330 sampler and the open-source web editor for modern workflows. |  |  | blog |  | manual | 2025-01-15 |  |
+| roland-s-series-samplers | The Roland S-Series Samplers: A Complete Guide to the S-330, S-550, S-770, and W-30 | A comprehensive guide to Roland's S-series sampler family — from the affordable S-330 to the flagship S-770, including the W-30 workstation, original accessories, and modern editing tools. |  |  | blog |  | manual | 2025-02-15 |  |
+| roland-s330-sampler-editor-feb-2026-update | What's New in the Roland S-330 Web Editor: February 2026 | Real-time hardware sync, integrated video capture, debug tools, and quality-of-life improvements for the free S-330 sampler editor. |  |  | blog |  | manual | 2026-02-09 |  |
+| reverse-engineering-akai-s3000xl-midi-over-scsi | Reverse-Engineering the Akai S3000XL MIDI-over-SCSI Protocol: An Odyssey | How a failed attempt to run Akai's MESA II in a Mac OS 9 emulator led us through 38 disproven theories in five days of intense debugging, and ultimately to a standalone 68k emulator that cracked the protocol in four hours. |  |  | blog |  | manual | 2026-04-07 |  |
+| scsi-over-wifi-raspberry-pi-bridge | SCSI Over WiFi: Talking to Vintage Hardware from Your Phone | An open-source Raspberry Pi bridge that lets you send SCSI commands to vintage samplers and computers over HTTP and WebSocket -- no SCSI card required. |  |  | blog |  | manual | 2026-04-07 |  |
+| claude-vs-codex-claude-perspective | Two AIs, One Feature: What Happens When Claude and Codex Build the Same Thing | Claude Code and Codex independently implemented the same draggable zone feature for the Akai S3000XL editor. The code was comparable. The sessions were not. |  |  | blog |  | manual | 2026-04-13 |  |
+| claude-vs-codex-codex-perspective | What Happened When We Asked Claude and Codex to Build the Same Feature | We asked two AI coding agents to implement the same draggable zone editing feature for the Akai S3000XL editor. The most useful comparison wasn't about code quality -- it was about failure modes. |  |  | blog |  | manual | 2026-04-13 |  |
+| what-2400-session-taught-us-about-agent-workflow | Instructions Are Not Enough: What 2,400 Sessions Taught Us About AI Agent Workflow | Telling an AI agent what to do is easy. Getting it to reliably follow process requires something structural — skills, session journals, and correction-driven guardrails. |  |  | blog |  | manual | 2026-04-17 |  |
+| s330-drum-crunch-video | Vintage 12-bit Sampler Drum Sounds for Cheap | Vintage 12-bit sampler crunch for drums using a ~$200 Roland S-330 plus the free web editor — turn any drum hits into dozens of crunchy kits. |  | samplers, vintage-hardware, roland, home-studio | youtube | https://youtu.be/jWgCQDdsyrw | manual | 2026-03-03 |  |
 
 ## Distribution
 
@@ -35,3 +36,7 @@
 |------|------|------|------|------|------|
 | claude-vs-codex-codex-perspective | reddit | https://www.reddit.com/r/ClaudeCode/comments/1smcjze/claude_vs_codex_cage_match/ | 2026-04-15 | r/ClaudeCode | Claude vs. Codex Cage Match |
 | claude-vs-codex-codex-perspective | reddit | https://www.reddit.com/r/codex/comments/1smd3jc/claude_vs_codex_cage_match/ | 2026-04-15 | r/codex | [ Removed by moderator ] |
+| s330-drum-crunch-video | reddit | https://www.reddit.com/r/synthdiy/comments/1rl9k63/roland_s330_12bit_crunch_for_drums_cheap/ | 2026-03-05 | r/synthdiy | Roland S-330 12-Bit Crunch for Drums, Cheap |
+| s330-drum-crunch-video | reddit | https://www.reddit.com/r/Samplers/comments/1rjyrac/roland_s330_12bit_crunch_for_drums_cheap/ | 2026-03-03 | r/Samplers | Roland S-330 12-Bit Crunch for Drums, Cheap |
+| s330-drum-crunch-video | reddit | https://www.reddit.com/r/synthesizers/comments/1rjyuuf/roland_s330_12bit_crunch_for_drums_cheap/ | 2026-03-03 | r/synthesizers | Roland S-330 12-Bit Crunch for Drums, Cheap |
+| s330-drum-crunch-video | reddit | https://www.reddit.com/r/Roland/comments/1rjyssb/roland_s330_12bit_crunch_for_drums_cheap/ | 2026-03-03 | r/Roland | Roland S-330 12-Bit Crunch for Drums, Cheap |

--- a/scripts/lib/editorial/calendar.ts
+++ b/scripts/lib/editorial/calendar.ts
@@ -34,7 +34,10 @@ import { readFileSync, writeFileSync } from 'fs';
 import {
   PLATFORMS,
   STAGES,
+  effectiveContentType,
+  isContentType,
   type CalendarEntry,
+  type ContentType,
   type DistributionRecord,
   type EditorialCalendar,
   type Platform,
@@ -131,6 +134,14 @@ function parseEntries(lines: string[], stage: Stage): CalendarEntry[] {
       if (topics) {
         entry.topics = topics.split(',').map((t) => t.trim()).filter(Boolean);
       }
+
+      const typeValue = col(cells, cols, 'type');
+      if (typeValue && isContentType(typeValue)) {
+        entry.contentType = typeValue;
+      }
+
+      const url = col(cells, cols, 'url');
+      if (url) entry.contentUrl = url;
 
       const published = col(cells, cols, 'published');
       if (published) entry.datePublished = published;
@@ -248,10 +259,20 @@ function renderStageTable(entries: CalendarEntry[], stage: Stage): string {
   const hasTopics = entries.some(
     (e) => e.topics !== undefined && e.topics.length > 0,
   );
+  // Emit Type column when any entry is non-blog
+  const hasType = entries.some(
+    (e) => e.contentType !== undefined && e.contentType !== 'blog',
+  );
+  // Emit URL column when any entry has a contentUrl
+  const hasUrl = entries.some(
+    (e) => e.contentUrl !== undefined && e.contentUrl !== '',
+  );
   const isPublished = stage === 'Published';
 
   const headers: string[] = ['Slug', 'Title', 'Description', 'Keywords'];
   if (hasTopics) headers.push('Topics');
+  if (hasType) headers.push('Type');
+  if (hasUrl) headers.push('URL');
   headers.push('Source');
   if (isPublished) headers.push('Published');
   if (hasIssue || isPublished) headers.push('Issue');
@@ -267,6 +288,8 @@ function renderStageTable(entries: CalendarEntry[], stage: Stage): string {
       escapeCell(e.targetKeywords.join(', ')),
     ];
     if (hasTopics) row.push(escapeCell((e.topics ?? []).join(', ')));
+    if (hasType) row.push(effectiveContentType(e));
+    if (hasUrl) row.push(escapeCell(e.contentUrl ?? ''));
     row.push(e.source);
     if (isPublished) row.push(e.datePublished ?? '');
     if (hasIssue || isPublished) row.push(e.issueNumber ? `#${e.issueNumber}` : '');

--- a/scripts/lib/editorial/crosslinks.ts
+++ b/scripts/lib/editorial/crosslinks.ts
@@ -1,0 +1,214 @@
+/**
+ * Cross-link audit between blog posts and YouTube videos.
+ *
+ * Closes the loop: for each Published entry, what does it link to, which
+ * of those links resolve to known calendar entries, and which don't
+ * reciprocate? The audit is bidirectional — a gap is "blog X links to
+ * video Y, but Y's description doesn't link back to X" OR vice versa.
+ *
+ * This module does no I/O on its own. It's given:
+ *  - the calendar (entries in memory)
+ *  - the blog MD content for each blog entry (read by the caller)
+ *  - a `fetchDescription(url)` closure that returns the YouTube video
+ *    description (caller wires this to YouTube Data API or a fixture)
+ *
+ * Keeping I/O at the edges makes the audit testable and lets callers
+ * swap in fixtures for tests or the live YouTube client in the skill.
+ */
+
+import { effectiveContentType, type CalendarEntry, type EditorialCalendar } from './types.js';
+import { extractVideoId } from '../youtube/client.js';
+
+/**
+ * Find YouTube URLs in a blog post's markdown body.
+ *
+ * Captures:
+ *  - plain `https://www.youtube.com/watch?v=...` and `https://youtu.be/...`
+ *  - shorts `https://www.youtube.com/shorts/...`
+ *  - `<iframe src="https://www.youtube.com/embed/...">` embeds
+ */
+export function extractYouTubeLinksFromMarkdown(md: string): string[] {
+  const urls = new Set<string>();
+
+  const patterns: RegExp[] = [
+    // youtube.com/watch?v=ID (URL, not necessarily inside a link)
+    /https?:\/\/(?:www\.|m\.)?youtube\.com\/watch\?[^\s"')]*v=[A-Za-z0-9_-]{11}[^\s"')]*/gi,
+    // youtu.be/ID
+    /https?:\/\/youtu\.be\/[A-Za-z0-9_-]{11}[^\s"')]*/gi,
+    // youtube.com/shorts/ID
+    /https?:\/\/(?:www\.)?youtube\.com\/shorts\/[A-Za-z0-9_-]{11}[^\s"')]*/gi,
+    // youtube.com/embed/ID (inside iframe src)
+    /https?:\/\/(?:www\.)?youtube\.com\/embed\/[A-Za-z0-9_-]{11}[^\s"')]*/gi,
+  ];
+
+  for (const pattern of patterns) {
+    const matches = md.matchAll(pattern);
+    for (const m of matches) urls.add(m[0]);
+  }
+
+  return [...urls];
+}
+
+/**
+ * Find audiocontrol.org blog URLs in a string (typically a YouTube video
+ * description). Returns the full URL; the caller is responsible for
+ * extracting the slug if needed.
+ */
+export function extractBlogLinksFromDescription(desc: string): string[] {
+  const urls = new Set<string>();
+  const pattern =
+    /https?:\/\/(?:www\.)?audiocontrol\.org\/blog\/[a-z0-9-]+\/?/gi;
+  const matches = desc.matchAll(pattern);
+  for (const m of matches) urls.add(m[0]);
+  return [...urls];
+}
+
+/** Extract the slug from an audiocontrol.org/blog/ URL. */
+export function slugFromBlogUrl(url: string): string | null {
+  const match = url.match(
+    /^https?:\/\/(?:www\.)?audiocontrol\.org\/blog\/([a-z0-9-]+)\/?/i,
+  );
+  return match ? match[1] : null;
+}
+
+/**
+ * One outbound link found in a calendar entry's content, resolved against
+ * the calendar so we can report whether the target is tracked.
+ */
+export interface OutboundLink {
+  /** Raw URL as it appears in the source content */
+  url: string;
+  /** Slug of the calendar entry this link points to, if any */
+  resolvedSlug: string | null;
+  /** Whether the target entry exists in the calendar */
+  resolved: boolean;
+}
+
+/** The audit result for a single calendar entry. */
+export interface EntryAudit {
+  entry: CalendarEntry;
+  /** Links found in this entry's content */
+  outbound: OutboundLink[];
+  /**
+   * Slugs of other entries that link to this one but are not reciprocated —
+   * i.e. other entries where `outbound` includes this entry's slug but this
+   * entry's `outbound` doesn't include theirs.
+   */
+  missingBacklinksTo: string[];
+  /** Free-form errors encountered during the audit for this entry (e.g. fetch failed). */
+  errors: string[];
+}
+
+export interface AuditCrossLinksInput {
+  calendar: EditorialCalendar;
+  /** Resolve a blog slug to its markdown body. Return null if unavailable. */
+  fetchBlogMarkdown: (slug: string) => string | null;
+  /** Fetch a YouTube video's description by the contentUrl. Returns null on failure. */
+  fetchVideoDescription: (contentUrl: string) => Promise<string | null>;
+}
+
+/** The complete audit report. */
+export interface AuditReport {
+  entries: EntryAudit[];
+}
+
+/**
+ * Run the cross-link audit against a calendar.
+ *
+ * Iterates Published entries, extracts outbound links from each, then
+ * does a second pass to detect non-reciprocated links. Returns a report
+ * with one EntryAudit per Published entry.
+ */
+export async function auditCrossLinks(
+  input: AuditCrossLinksInput,
+): Promise<AuditReport> {
+  const { calendar, fetchBlogMarkdown, fetchVideoDescription } = input;
+  const published = calendar.entries.filter((e) => e.stage === 'Published');
+
+  const bySlug = new Map<string, CalendarEntry>();
+  const byVideoId = new Map<string, CalendarEntry>();
+  for (const e of published) {
+    bySlug.set(e.slug, e);
+    if (effectiveContentType(e) === 'youtube' && e.contentUrl) {
+      try {
+        byVideoId.set(extractVideoId(e.contentUrl), e);
+      } catch {
+        // contentUrl is present but not a recognizable YouTube URL — skip indexing
+      }
+    }
+  }
+
+  // First pass: per-entry outbound links
+  const audits: EntryAudit[] = [];
+  for (const entry of published) {
+    const outbound: OutboundLink[] = [];
+    const errors: string[] = [];
+
+    if (effectiveContentType(entry) === 'blog') {
+      const md = fetchBlogMarkdown(entry.slug);
+      if (md === null) {
+        errors.push(`could not read blog markdown for ${entry.slug}`);
+      } else {
+        for (const url of extractYouTubeLinksFromMarkdown(md)) {
+          let resolvedSlug: string | null = null;
+          try {
+            const id = extractVideoId(url);
+            const target = byVideoId.get(id);
+            if (target) resolvedSlug = target.slug;
+          } catch {
+            // unparseable — treat as unresolved
+          }
+          outbound.push({ url, resolvedSlug, resolved: resolvedSlug !== null });
+        }
+      }
+    } else if (effectiveContentType(entry) === 'youtube') {
+      if (!entry.contentUrl) {
+        errors.push(`YouTube entry ${entry.slug} has no contentUrl`);
+      } else {
+        let desc: string | null = null;
+        try {
+          desc = await fetchVideoDescription(entry.contentUrl);
+        } catch (err) {
+          errors.push(
+            `fetching description for ${entry.slug}: ${(err as Error).message}`,
+          );
+        }
+        if (desc !== null) {
+          for (const url of extractBlogLinksFromDescription(desc)) {
+            const slug = slugFromBlogUrl(url);
+            const resolvedSlug = slug && bySlug.has(slug) ? slug : null;
+            outbound.push({
+              url,
+              resolvedSlug,
+              resolved: resolvedSlug !== null,
+            });
+          }
+        }
+      }
+    }
+
+    audits.push({ entry, outbound, missingBacklinksTo: [], errors });
+  }
+
+  // Second pass: detect missing backlinks. For each audit A, find every
+  // audit B where B.outbound resolves to A.entry.slug but A.outbound does
+  // NOT resolve to B.entry.slug. Add B's slug to A.missingBacklinksTo.
+  const auditBySlug = new Map<string, EntryAudit>();
+  for (const a of audits) auditBySlug.set(a.entry.slug, a);
+
+  for (const b of audits) {
+    for (const link of b.outbound) {
+      if (!link.resolvedSlug) continue;
+      const a = auditBySlug.get(link.resolvedSlug);
+      if (!a) continue;
+      const reciprocated = a.outbound.some(
+        (l) => l.resolvedSlug === b.entry.slug,
+      );
+      if (!reciprocated && !a.missingBacklinksTo.includes(b.entry.slug)) {
+        a.missingBacklinksTo.push(b.entry.slug);
+      }
+    }
+  }
+
+  return { entries: audits };
+}

--- a/scripts/lib/editorial/crosslinks.ts
+++ b/scripts/lib/editorial/crosslinks.ts
@@ -171,7 +171,7 @@ export async function auditCrossLinks(
           outbound.push({ url, resolvedSlug, resolved: resolvedSlug !== null });
         }
       }
-    } else if (effectiveContentType(entry) === 'youtube') {
+    } else if (entryType === 'youtube') {
       if (!entry.contentUrl) {
         errors.push(`YouTube entry ${entry.slug} has no contentUrl`);
       } else {
@@ -179,8 +179,9 @@ export async function auditCrossLinks(
         try {
           desc = await fetchVideoDescription(entry.contentUrl);
         } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
           errors.push(
-            `fetching description for ${entry.slug}: ${(err as Error).message}`,
+            `fetching description for ${entry.slug}: ${message}`,
           );
         }
         if (desc !== null) {

--- a/scripts/lib/editorial/crosslinks.ts
+++ b/scripts/lib/editorial/crosslinks.ts
@@ -144,7 +144,17 @@ export async function auditCrossLinks(
     const outbound: OutboundLink[] = [];
     const errors: string[] = [];
 
-    if (effectiveContentType(entry) === 'blog') {
+    const entryType = effectiveContentType(entry);
+
+    // Tool entries are tracked in the calendar but the cross-link audit
+    // doesn't analyze them yet: they have no MD file we own and no
+    // fetch-able description. Tool-audit support is a follow-up.
+    if (entryType === 'tool') {
+      audits.push({ entry, outbound: [], missingBacklinksTo: [], errors: [] });
+      continue;
+    }
+
+    if (entryType === 'blog') {
       const md = fetchBlogMarkdown(entry.slug);
       if (md === null) {
         errors.push(`could not read blog markdown for ${entry.slug}`);
@@ -201,6 +211,10 @@ export async function auditCrossLinks(
       if (!link.resolvedSlug) continue;
       const a = auditBySlug.get(link.resolvedSlug);
       if (!a) continue;
+      // Tool entries are not audited for outbound links, so reciprocation
+      // isn't meaningful — skip to avoid false-positive "missing backlink"
+      // flags against every tool.
+      if (effectiveContentType(a.entry) === 'tool') continue;
       const reciprocated = a.outbound.some(
         (l) => l.resolvedSlug === b.entry.slug,
       );

--- a/scripts/lib/editorial/index.ts
+++ b/scripts/lib/editorial/index.ts
@@ -1,13 +1,17 @@
 export {
+  CONTENT_TYPES,
   PLATFORMS,
   STAGES,
+  type ContentType,
   type Platform,
   type Stage,
   type CalendarEntry,
   type DistributionRecord,
   type EditorialCalendar,
   distributionsBySlug,
+  effectiveContentType,
   entriesByStage,
+  isContentType,
 } from './types.js';
 
 export {
@@ -35,6 +39,17 @@ export {
   alreadyShared,
   type ChannelEntry,
 } from './channels.js';
+
+export {
+  extractYouTubeLinksFromMarkdown,
+  extractBlogLinksFromDescription,
+  slugFromBlogUrl,
+  auditCrossLinks,
+  type OutboundLink,
+  type EntryAudit,
+  type AuditReport,
+  type AuditCrossLinksInput,
+} from './crosslinks.js';
 
 export {
   getContentSuggestions,

--- a/scripts/lib/editorial/index.ts
+++ b/scripts/lib/editorial/index.ts
@@ -11,7 +11,9 @@ export {
   distributionsBySlug,
   effectiveContentType,
   entriesByStage,
+  hasRepoContent,
   isContentType,
+  requiresContentUrl,
 } from './types.js';
 
 export {

--- a/scripts/lib/editorial/types.ts
+++ b/scripts/lib/editorial/types.ts
@@ -16,6 +16,11 @@ export const STAGES = [
 
 export type Stage = (typeof STAGES)[number];
 
+/** What kind of content a calendar entry represents. */
+export const CONTENT_TYPES = ['blog', 'youtube'] as const;
+
+export type ContentType = (typeof CONTENT_TYPES)[number];
+
 /** A single entry in the editorial calendar. */
 export interface CalendarEntry {
   /** URL-safe identifier, e.g. "scsi-over-wifi-raspberry-pi-bridge" */
@@ -26,6 +31,18 @@ export interface CalendarEntry {
   description: string;
   /** Current editorial stage */
   stage: Stage;
+  /**
+   * What kind of content this entry represents. Optional in storage —
+   * entries without an explicit type default to `'blog'` on parse, so
+   * pre-Phase-6 calendars remain valid.
+   */
+  contentType?: ContentType;
+  /**
+   * Canonical URL for content that doesn't live at `/blog/<slug>/`.
+   * Required for `youtube` entries once published. Omitted for `blog`
+   * entries (URL is derived from slug).
+   */
+  contentUrl?: string;
   /** Target SEO keywords (set when moving to Planned) */
   targetKeywords: string[];
   /**
@@ -40,6 +57,20 @@ export interface CalendarEntry {
   issueNumber?: number;
   /** How this entry was sourced */
   source: 'manual' | 'analytics';
+}
+
+/** True if a value is a recognized content type. */
+export function isContentType(value: string): value is ContentType {
+  return (CONTENT_TYPES as readonly string[]).includes(value);
+}
+
+/**
+ * Return the effective content type for an entry — `'blog'` when unset.
+ * Use this everywhere that needs to branch on type, so legacy entries
+ * (no contentType) keep behaving like blog posts.
+ */
+export function effectiveContentType(entry: CalendarEntry): ContentType {
+  return entry.contentType ?? 'blog';
 }
 
 /** Social platforms we track distribution to. */

--- a/scripts/lib/editorial/types.ts
+++ b/scripts/lib/editorial/types.ts
@@ -16,8 +16,14 @@ export const STAGES = [
 
 export type Stage = (typeof STAGES)[number];
 
-/** What kind of content a calendar entry represents. */
-export const CONTENT_TYPES = ['blog', 'youtube'] as const;
+/** What kind of content a calendar entry represents.
+ *
+ * - `blog`    — content lives in this repo under `src/pages/blog/<slug>/`
+ * - `youtube` — video hosted on YouTube; `contentUrl` is the video URL
+ * - `tool`    — standalone tool or app on audiocontrol.org (e.g. an editor page);
+ *               `contentUrl` is the canonical page URL
+ */
+export const CONTENT_TYPES = ['blog', 'youtube', 'tool'] as const;
 
 export type ContentType = (typeof CONTENT_TYPES)[number];
 
@@ -71,6 +77,24 @@ export function isContentType(value: string): value is ContentType {
  */
 export function effectiveContentType(entry: CalendarEntry): ContentType {
   return entry.contentType ?? 'blog';
+}
+
+/**
+ * True if this content type has a source file in the repo that
+ * `/editorial-draft` should scaffold. Only blog posts live in the repo;
+ * youtube videos and tools live externally.
+ */
+export function hasRepoContent(contentType: ContentType): boolean {
+  return contentType === 'blog';
+}
+
+/**
+ * True if this content type requires `contentUrl` to be set before publishing.
+ * Blog entries derive their URL from the slug; everything else needs an
+ * explicit URL.
+ */
+export function requiresContentUrl(contentType: ContentType): boolean {
+  return contentType !== 'blog';
 }
 
 /** Social platforms we track distribution to. */

--- a/scripts/lib/youtube/client.ts
+++ b/scripts/lib/youtube/client.ts
@@ -1,0 +1,123 @@
+/**
+ * Minimal YouTube Data API v3 client.
+ *
+ * We need exactly one operation: fetch a video's metadata (title,
+ * description, channel, publish date) given a video ID or URL. Used by
+ * the cross-link audit to extract audiocontrol.org URLs from YouTube
+ * video descriptions.
+ *
+ * One API call = 1 quota unit. Free tier is 10,000 units/day — effectively
+ * unlimited for our use case.
+ */
+
+import { loadConfig } from './config.js';
+
+const YOUTUBE_API_BASE = 'https://www.googleapis.com/youtube/v3';
+
+export interface VideoMetadata {
+  /** Canonical 11-char video ID */
+  id: string;
+  title: string;
+  description: string;
+  channelTitle: string;
+  channelId: string;
+  /** ISO timestamp of the publishedAt field */
+  publishedAt: string;
+}
+
+interface VideoListResponse {
+  items?: Array<{
+    id: string;
+    snippet?: {
+      title?: string;
+      description?: string;
+      channelTitle?: string;
+      channelId?: string;
+      publishedAt?: string;
+    };
+  }>;
+}
+
+/**
+ * Extract an 11-character video ID from a YouTube URL or return the input
+ * if it already looks like a bare ID.
+ *
+ * Supported URL forms:
+ *   - `https://www.youtube.com/watch?v=<id>`
+ *   - `https://youtu.be/<id>`
+ *   - `https://www.youtube.com/shorts/<id>`
+ *   - `https://www.youtube.com/embed/<id>`
+ */
+export function extractVideoId(input: string): string {
+  const value = input.trim();
+  if (!value) throw new Error('extractVideoId: empty input');
+
+  // Bare 11-char ID shape
+  if (/^[A-Za-z0-9_-]{11}$/.test(value)) return value;
+
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(`extractVideoId: not a bare ID and not a parseable URL: ${value}`);
+  }
+
+  const host = url.hostname.toLowerCase();
+
+  // youtu.be/<id>
+  if (host === 'youtu.be' || host.endsWith('.youtu.be')) {
+    const id = url.pathname.replace(/^\//, '').split('/')[0];
+    if (/^[A-Za-z0-9_-]{11}$/.test(id)) return id;
+  }
+
+  // youtube.com/watch?v=<id>
+  if (host === 'youtube.com' || host.endsWith('.youtube.com')) {
+    const v = url.searchParams.get('v');
+    if (v && /^[A-Za-z0-9_-]{11}$/.test(v)) return v;
+
+    // youtube.com/shorts/<id> or /embed/<id>
+    const match = url.pathname.match(/^\/(?:shorts|embed)\/([A-Za-z0-9_-]{11})/);
+    if (match) return match[1];
+  }
+
+  throw new Error(`extractVideoId: could not extract a video ID from ${value}`);
+}
+
+/** Fetch metadata for a single YouTube video. */
+export async function getVideoMetadata(
+  videoIdOrUrl: string,
+): Promise<VideoMetadata> {
+  const config = loadConfig();
+  const id = extractVideoId(videoIdOrUrl);
+
+  const url = new URL(`${YOUTUBE_API_BASE}/videos`);
+  url.searchParams.set('part', 'snippet');
+  url.searchParams.set('id', id);
+  url.searchParams.set('key', config.apiKey);
+
+  const response = await fetch(url.toString(), {
+    headers: { Accept: 'application/json' },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `YouTube API error ${response.status} ${response.statusText} for video ${id}: ${body.slice(0, 500)}`,
+    );
+  }
+
+  const data = (await response.json()) as VideoListResponse;
+  const item = data.items?.[0];
+  if (!item) {
+    throw new Error(`YouTube API returned no items for video ${id}`);
+  }
+  const snippet = item.snippet ?? {};
+  return {
+    id: item.id,
+    title: snippet.title ?? '',
+    description: snippet.description ?? '',
+    channelTitle: snippet.channelTitle ?? '',
+    channelId: snippet.channelId ?? '',
+    publishedAt: snippet.publishedAt ?? '',
+  };
+}

--- a/scripts/lib/youtube/config.ts
+++ b/scripts/lib/youtube/config.ts
@@ -1,0 +1,48 @@
+/**
+ * YouTube Data API v3 configuration.
+ *
+ * One key in one file — same pattern as the other audiocontrol tooling.
+ *
+ * Config: `~/.config/audiocontrol/youtube.json`
+ *
+ * ```json
+ * { "apiKey": "AIza..." }
+ * ```
+ *
+ * Setup steps (one-time):
+ * 1. https://console.cloud.google.com → pick or create a project
+ * 2. APIs & Services → Library → enable "YouTube Data API v3"
+ * 3. Credentials → Create credentials → API key
+ * 4. Restrict the key to YouTube Data API v3 for hygiene
+ * 5. Save the key in the JSON above
+ *
+ * If the file is missing we throw with these steps — no silent fallback.
+ */
+
+import { readFileSync } from 'fs';
+
+const YOUTUBE_CONFIG_PATH = `${process.env.HOME}/.config/audiocontrol/youtube.json`;
+
+export interface YouTubeConfig {
+  apiKey: string;
+}
+
+export function loadConfig(): YouTubeConfig {
+  let raw: string;
+  try {
+    raw = readFileSync(YOUTUBE_CONFIG_PATH, 'utf-8');
+  } catch {
+    throw new Error(
+      `YouTube config not found at ${YOUTUBE_CONFIG_PATH}. ` +
+        `Create it with: {"apiKey": "AIza..."} — see the file header of ` +
+        `scripts/lib/youtube/config.ts for setup instructions.`,
+    );
+  }
+  const parsed = JSON.parse(raw) as Partial<YouTubeConfig>;
+  if (!parsed.apiKey || typeof parsed.apiKey !== 'string' || !parsed.apiKey.trim()) {
+    throw new Error(
+      `Missing or empty "apiKey" in ${YOUTUBE_CONFIG_PATH}`,
+    );
+  }
+  return { apiKey: parsed.apiKey.trim() };
+}

--- a/scripts/lib/youtube/config.ts
+++ b/scripts/lib/youtube/config.ts
@@ -1,27 +1,26 @@
 /**
  * YouTube Data API v3 configuration.
  *
- * One key in one file — same pattern as the other audiocontrol tooling.
+ * The API key is read from a plain-text file, matching the convention
+ * used by other single-secret credentials in `~/.config/audiocontrol/`
+ * (flux-key.txt, openai-key.txt, etc.):
  *
- * Config: `~/.config/audiocontrol/youtube.json`
- *
- * ```json
- * { "apiKey": "AIza..." }
- * ```
+ *   `~/.config/audiocontrol/youtube-key.txt`  — one line containing
+ *   the `AIza...` key.
  *
  * Setup steps (one-time):
  * 1. https://console.cloud.google.com → pick or create a project
  * 2. APIs & Services → Library → enable "YouTube Data API v3"
  * 3. Credentials → Create credentials → API key
  * 4. Restrict the key to YouTube Data API v3 for hygiene
- * 5. Save the key in the JSON above
+ * 5. `echo "AIza..." > ~/.config/audiocontrol/youtube-key.txt`
  *
  * If the file is missing we throw with these steps — no silent fallback.
  */
 
 import { readFileSync } from 'fs';
 
-const YOUTUBE_CONFIG_PATH = `${process.env.HOME}/.config/audiocontrol/youtube.json`;
+const YOUTUBE_KEY_PATH = `${process.env.HOME}/.config/audiocontrol/youtube-key.txt`;
 
 export interface YouTubeConfig {
   apiKey: string;
@@ -30,19 +29,19 @@ export interface YouTubeConfig {
 export function loadConfig(): YouTubeConfig {
   let raw: string;
   try {
-    raw = readFileSync(YOUTUBE_CONFIG_PATH, 'utf-8');
+    raw = readFileSync(YOUTUBE_KEY_PATH, 'utf-8');
   } catch {
     throw new Error(
-      `YouTube config not found at ${YOUTUBE_CONFIG_PATH}. ` +
-        `Create it with: {"apiKey": "AIza..."} — see the file header of ` +
-        `scripts/lib/youtube/config.ts for setup instructions.`,
+      `YouTube API key not found at ${YOUTUBE_KEY_PATH}. ` +
+        `Create the file with your API key on a single line — see the file ` +
+        `header of scripts/lib/youtube/config.ts for setup instructions.`,
     );
   }
-  const parsed = JSON.parse(raw) as Partial<YouTubeConfig>;
-  if (!parsed.apiKey || typeof parsed.apiKey !== 'string' || !parsed.apiKey.trim()) {
+  const apiKey = raw.trim();
+  if (!apiKey) {
     throw new Error(
-      `Missing or empty "apiKey" in ${YOUTUBE_CONFIG_PATH}`,
+      `YouTube API key file ${YOUTUBE_KEY_PATH} is empty`,
     );
   }
-  return { apiKey: parsed.apiKey.trim() };
+  return { apiKey };
 }

--- a/scripts/lib/youtube/index.ts
+++ b/scripts/lib/youtube/index.ts
@@ -1,0 +1,6 @@
+export { loadConfig, type YouTubeConfig } from './config.js';
+export {
+  extractVideoId,
+  getVideoMetadata,
+  type VideoMetadata,
+} from './client.js';

--- a/test/editorial/phase6.test.ts
+++ b/test/editorial/phase6.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Unit tests for Phase 6 additions:
+ * - contentType + contentUrl on CalendarEntry (round-trip + backwards compat)
+ * - crosslinks: extract YouTube URLs from markdown, extract blog URLs from
+ *   YouTube descriptions, audit bidirectional coverage
+ * - extractVideoId across URL forms
+ *
+ * Run with: npm test
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  parseCalendar,
+  renderCalendar,
+  type CalendarEntry,
+  type EditorialCalendar,
+} from '../../scripts/lib/editorial/index.js';
+import {
+  auditCrossLinks,
+  extractBlogLinksFromDescription,
+  extractYouTubeLinksFromMarkdown,
+  slugFromBlogUrl,
+} from '../../scripts/lib/editorial/crosslinks.js';
+import { extractVideoId } from '../../scripts/lib/youtube/client.js';
+
+function emptyCalendar(): EditorialCalendar {
+  return { entries: [], distributions: [] };
+}
+
+function blogEntry(slug: string): CalendarEntry {
+  return {
+    slug,
+    title: slug,
+    description: '',
+    stage: 'Published',
+    targetKeywords: [],
+    source: 'manual',
+    datePublished: '2026-04-01',
+  };
+}
+
+function videoEntry(slug: string, contentUrl: string): CalendarEntry {
+  return {
+    slug,
+    title: slug,
+    description: '',
+    stage: 'Published',
+    contentType: 'youtube',
+    contentUrl,
+    targetKeywords: [],
+    source: 'manual',
+    datePublished: '2026-04-01',
+  };
+}
+
+describe('contentType + contentUrl columns', () => {
+  it('round-trips a YouTube entry', () => {
+    const cal: EditorialCalendar = {
+      entries: [videoEntry('s330-crunch-video', 'https://youtu.be/jWgCQDdsyrw')],
+      distributions: [],
+    };
+    const md = renderCalendar(cal);
+    expect(md).toMatch(/\| Type \|/);
+    expect(md).toMatch(/\| URL \|/);
+    expect(md).toContain('youtube');
+    expect(md).toContain('https://youtu.be/jWgCQDdsyrw');
+    const reparsed = parseCalendar(md);
+    expect(reparsed.entries[0].contentType).toBe('youtube');
+    expect(reparsed.entries[0].contentUrl).toBe('https://youtu.be/jWgCQDdsyrw');
+  });
+
+  it('omits Type and URL columns when all entries are plain blogs', () => {
+    const cal: EditorialCalendar = {
+      entries: [blogEntry('regular-post')],
+      distributions: [],
+    };
+    const md = renderCalendar(cal);
+    expect(md).not.toMatch(/\| Type \|/);
+    expect(md).not.toMatch(/\| URL \|/);
+  });
+
+  it('backwards-compat: a legacy Published row without Type/URL parses as blog', () => {
+    const md = [
+      '# Editorial Calendar',
+      '',
+      '## Published',
+      '',
+      '| Slug | Title | Description | Keywords | Source | Published | Issue |',
+      '|------|-------|-------------|----------|--------|-----------|-------|',
+      '| legacy-post | Legacy | d | kw | manual | 2026-03-01 |  |',
+      '',
+    ].join('\n');
+    const cal = parseCalendar(md);
+    expect(cal.entries).toHaveLength(1);
+    expect(cal.entries[0].contentType).toBeUndefined();
+    expect(cal.entries[0].contentUrl).toBeUndefined();
+  });
+});
+
+describe('extractVideoId', () => {
+  it.each([
+    ['jWgCQDdsyrw', 'jWgCQDdsyrw'],
+    ['https://youtu.be/jWgCQDdsyrw', 'jWgCQDdsyrw'],
+    ['https://youtu.be/jWgCQDdsyrw?t=42', 'jWgCQDdsyrw'],
+    ['https://www.youtube.com/watch?v=jWgCQDdsyrw', 'jWgCQDdsyrw'],
+    ['https://www.youtube.com/watch?v=jWgCQDdsyrw&t=42s', 'jWgCQDdsyrw'],
+    ['https://youtube.com/shorts/jWgCQDdsyrw', 'jWgCQDdsyrw'],
+    ['https://www.youtube.com/embed/jWgCQDdsyrw', 'jWgCQDdsyrw'],
+    ['https://m.youtube.com/watch?v=jWgCQDdsyrw', 'jWgCQDdsyrw'],
+  ])('extracts ID from %s', (input, expected) => {
+    expect(extractVideoId(input)).toBe(expected);
+  });
+
+  it('throws on empty input', () => {
+    expect(() => extractVideoId('')).toThrow();
+  });
+
+  it('throws on a URL without a recognizable video ID', () => {
+    expect(() => extractVideoId('https://youtube.com/results?search_query=foo')).toThrow();
+  });
+});
+
+describe('extractYouTubeLinksFromMarkdown', () => {
+  it('extracts plain watch and short URLs', () => {
+    const md = `
+Here's a video: https://www.youtube.com/watch?v=abcdefghijk
+
+And another: https://youtu.be/zyxwvutsrqp
+`;
+    const urls = extractYouTubeLinksFromMarkdown(md);
+    expect(urls).toHaveLength(2);
+    expect(urls).toContain('https://www.youtube.com/watch?v=abcdefghijk');
+    expect(urls).toContain('https://youtu.be/zyxwvutsrqp');
+  });
+
+  it('extracts shorts and iframe embeds', () => {
+    const md = `
+Short: https://www.youtube.com/shorts/aaaaaaaaaaa
+
+<iframe src="https://www.youtube.com/embed/bbbbbbbbbbb" />
+`;
+    const urls = extractYouTubeLinksFromMarkdown(md);
+    expect(urls).toContain('https://www.youtube.com/shorts/aaaaaaaaaaa');
+    expect(urls).toContain('https://www.youtube.com/embed/bbbbbbbbbbb');
+  });
+
+  it('deduplicates repeated URLs', () => {
+    const md = `
+Once: https://youtu.be/abcdefghijk
+Again: https://youtu.be/abcdefghijk
+`;
+    expect(extractYouTubeLinksFromMarkdown(md)).toHaveLength(1);
+  });
+
+  it('returns empty when there are no YouTube URLs', () => {
+    const md = 'Plain text with no links and a [fake](https://example.com/youtube) reference';
+    expect(extractYouTubeLinksFromMarkdown(md)).toEqual([]);
+  });
+});
+
+describe('extractBlogLinksFromDescription', () => {
+  it('extracts audiocontrol.org/blog/ URLs', () => {
+    const desc = `
+Full article: https://audiocontrol.org/blog/scsi-over-wifi-raspberry-pi-bridge/
+
+Also see: https://www.audiocontrol.org/blog/roland-s-series-samplers
+`;
+    const urls = extractBlogLinksFromDescription(desc);
+    expect(urls).toHaveLength(2);
+    expect(urls).toContain('https://audiocontrol.org/blog/scsi-over-wifi-raspberry-pi-bridge/');
+    expect(urls).toContain('https://www.audiocontrol.org/blog/roland-s-series-samplers');
+  });
+
+  it('ignores audiocontrol.org URLs that are not /blog/', () => {
+    const desc = 'https://audiocontrol.org/roland/s330/editor';
+    expect(extractBlogLinksFromDescription(desc)).toEqual([]);
+  });
+});
+
+describe('slugFromBlogUrl', () => {
+  it.each([
+    ['https://audiocontrol.org/blog/slug-one/', 'slug-one'],
+    ['https://audiocontrol.org/blog/slug-two', 'slug-two'],
+    ['https://www.audiocontrol.org/blog/slug-three/', 'slug-three'],
+    ['http://audiocontrol.org/blog/slug-four/', 'slug-four'],
+  ])('extracts slug from %s', (url, expected) => {
+    expect(slugFromBlogUrl(url)).toBe(expected);
+  });
+
+  it('returns null for non-blog URLs', () => {
+    expect(slugFromBlogUrl('https://audiocontrol.org/roland/s330')).toBeNull();
+  });
+});
+
+describe('auditCrossLinks', () => {
+  const VIDEO_URL = 'https://youtu.be/jWgCQDdsyrw';
+
+  const calendar: EditorialCalendar = {
+    entries: [
+      blogEntry('s330-post'),
+      videoEntry('s330-video', VIDEO_URL),
+      blogEntry('lonely-post'),
+    ],
+    distributions: [],
+  };
+
+  const blogBodies: Record<string, string> = {
+    's330-post': `Watch the demo: ${VIDEO_URL}`,
+    'lonely-post': 'No video here.',
+  };
+
+  it('reports a reciprocated link as no-gap', async () => {
+    const report = await auditCrossLinks({
+      calendar,
+      fetchBlogMarkdown: (slug) => blogBodies[slug] ?? null,
+      fetchVideoDescription: async () =>
+        'Read more at https://audiocontrol.org/blog/s330-post/',
+    });
+    const postAudit = report.entries.find((a) => a.entry.slug === 's330-post');
+    const videoAudit = report.entries.find((a) => a.entry.slug === 's330-video');
+    expect(postAudit?.outbound[0].resolvedSlug).toBe('s330-video');
+    expect(videoAudit?.outbound[0].resolvedSlug).toBe('s330-post');
+    expect(postAudit?.missingBacklinksTo).toEqual([]);
+    expect(videoAudit?.missingBacklinksTo).toEqual([]);
+  });
+
+  it('flags a missing backlink when the video description does not reciprocate', async () => {
+    const report = await auditCrossLinks({
+      calendar,
+      fetchBlogMarkdown: (slug) => blogBodies[slug] ?? null,
+      fetchVideoDescription: async () => 'No blog links here.',
+    });
+    const videoAudit = report.entries.find((a) => a.entry.slug === 's330-video');
+    // The blog post links TO the video but the video does NOT link BACK to the post.
+    // The video's audit should list the post in missingBacklinksTo.
+    expect(videoAudit?.missingBacklinksTo).toContain('s330-post');
+  });
+
+  it('captures errors when the blog markdown is unavailable', async () => {
+    const report = await auditCrossLinks({
+      calendar,
+      fetchBlogMarkdown: () => null,
+      fetchVideoDescription: async () => '',
+    });
+    const postAudit = report.entries.find((a) => a.entry.slug === 's330-post');
+    expect(postAudit?.errors.length).toBeGreaterThan(0);
+  });
+
+  it('records YouTube entries with missing contentUrl as errors', async () => {
+    const cal: EditorialCalendar = {
+      entries: [
+        {
+          slug: 'video-without-url',
+          title: 't',
+          description: '',
+          stage: 'Published',
+          contentType: 'youtube',
+          targetKeywords: [],
+          source: 'manual',
+          datePublished: '2026-04-01',
+        },
+      ],
+      distributions: [],
+    };
+    const report = await auditCrossLinks({
+      calendar: cal,
+      fetchBlogMarkdown: () => null,
+      fetchVideoDescription: async () => '',
+    });
+    expect(report.entries[0].errors.join(' ')).toMatch(/no contentUrl/);
+  });
+});

--- a/test/editorial/phase6.test.ts
+++ b/test/editorial/phase6.test.ts
@@ -54,6 +54,33 @@ function videoEntry(slug: string, contentUrl: string): CalendarEntry {
 }
 
 describe('contentType + contentUrl columns', () => {
+  it('round-trips a tool entry', () => {
+    const cal: EditorialCalendar = {
+      entries: [
+        {
+          slug: 's330-editor',
+          title: 'Roland S-330 Web Editor',
+          description: 'Free open-source web editor',
+          stage: 'Published',
+          contentType: 'tool',
+          contentUrl: 'https://audiocontrol.org/roland/s330/editor',
+          targetKeywords: [],
+          source: 'manual',
+          datePublished: '2025-01-01',
+        },
+      ],
+      distributions: [],
+    };
+    const md = renderCalendar(cal);
+    expect(md).toMatch(/\| Type \|/);
+    expect(md).toContain('tool');
+    const reparsed = parseCalendar(md);
+    expect(reparsed.entries[0].contentType).toBe('tool');
+    expect(reparsed.entries[0].contentUrl).toBe(
+      'https://audiocontrol.org/roland/s330/editor',
+    );
+  });
+
   it('round-trips a YouTube entry', () => {
     const cal: EditorialCalendar = {
       entries: [videoEntry('s330-crunch-video', 'https://youtu.be/jWgCQDdsyrw')],
@@ -244,6 +271,34 @@ describe('auditCrossLinks', () => {
     });
     const postAudit = report.entries.find((a) => a.entry.slug === 's330-post');
     expect(postAudit?.errors.length).toBeGreaterThan(0);
+  });
+
+  it('skips tool entries cleanly — no outbound links, no errors, no false-positive backlink gaps', async () => {
+    const cal: EditorialCalendar = {
+      entries: [
+        {
+          slug: 's330-editor',
+          title: 'Roland S-330 Web Editor',
+          description: '',
+          stage: 'Published',
+          contentType: 'tool',
+          contentUrl: 'https://audiocontrol.org/roland/s330/editor',
+          targetKeywords: [],
+          source: 'manual',
+          datePublished: '2025-01-01',
+        },
+      ],
+      distributions: [],
+    };
+    const report = await auditCrossLinks({
+      calendar: cal,
+      fetchBlogMarkdown: () => null,
+      fetchVideoDescription: async () => '',
+    });
+    const toolAudit = report.entries.find((a) => a.entry.slug === 's330-editor');
+    expect(toolAudit?.outbound).toEqual([]);
+    expect(toolAudit?.missingBacklinksTo).toEqual([]);
+    expect(toolAudit?.errors).toEqual([]);
   });
 
   it('records YouTube entries with missing contentUrl as errors', async () => {


### PR DESCRIPTION
## Summary

- Phase 6 of the editorial calendar: YouTube videos and tools become first-class calendar entries with the same Ideas → Planned → Drafting → Review → Published lifecycle as blog posts
- New `/editorial-cross-link-review` skill audits bidirectional linking between blog posts and YouTube videos, flagging gaps in either direction
- YouTube Data API v3 integration — single API key in `~/.config/audiocontrol/youtube-key.txt`, no OAuth
- `/editorial-reddit-sync` now attributes YouTube-URL Reddit submissions to the matching YouTube calendar entry
- S-330 drum-crunch demo video + S-330 web editor added as calendar entries; 6 previously-unmatched Reddit shares from the first Phase 5 sync are now attributed
- Phase 7 (tool cross-link audit) documented as a follow-up — tool entries are tracked in this PR but not yet audited; Phase 7 closes that loop

## Changes

**Data model**
- `CalendarEntry.contentType: 'blog' | 'youtube' | 'tool'` (optional during parse, defaults to `'blog'` — legacy calendars still parse)
- `CalendarEntry.contentUrl?: string` — canonical URL for non-blog content
- `effectiveContentType`, `hasRepoContent`, `requiresContentUrl`, `isContentType` helpers
- Parser/writer gains optional `Type` and `URL` columns, emitted only when used (same pattern as Phase 5's Topics/Channel)

**YouTube client**
- `scripts/lib/youtube/config.ts` — loads the API key from `~/.config/audiocontrol/youtube-key.txt` (matches existing `flux-key.txt` / `openai-key.txt` convention)
- `scripts/lib/youtube/client.ts` — `getVideoMetadata` via `/youtube/v3/videos?part=snippet`; `extractVideoId` across watch/shorts/youtu.be/embed/bare-ID forms

**Cross-link audit**
- `scripts/lib/editorial/crosslinks.ts` — pure functions for link extraction + gap detection; I/O at the edges so tests use fixtures and the live skill wires in the YouTube client
- Tool entries are tracked in the calendar but skipped cleanly in both passes of the audit (Phase 7 adds full tool-page analysis)

**New skill**
- `/editorial-cross-link-review` — reports per-entry outbound links, missing reciprocations, unresolved URLs, per-entry errors

**Updated skills**
- `/editorial-add` prompts for content type
- `/editorial-draft` uses `hasRepoContent` to branch: blog scaffolds directory + MD + issue; youtube/tool create issue only
- `/editorial-publish` uses `requiresContentUrl` to enforce URL for non-blog entries
- `/editorial-reddit-sync` matches YouTube URLs against YouTube entries' `contentUrl` via `extractVideoId`
- `/editorial-help` covers the new skills and content types

## Commits

- `dc2a841` — feat: Phase 6 — YouTube as first-class content + cross-link audit
- `f446daa` — fix: use `~/.config/audiocontrol/youtube-key.txt` matching existing convention
- `9b9a701` — content: add S-330 drum crunch video + attribute 4 Reddit shares
- `00dd9bd` — feat: add 'tool' as a third content type + register S-330 editor
- `24c9d4d` — docs: scope Phase 7 — tool cross-link audit
- `f98bf75` — refactor: address Phase 6 code review (remove `as Error` cast, reuse entryType)

## Test plan

- [x] `npm test` — 63/63 unit tests pass (10 Phase 4 + 23 Phase 5 + 30 Phase 6 covering contentType round-trip, Type/URL column emission, backwards-compat parsing, `extractVideoId` URL forms, YouTube/blog link extraction, bidirectional `auditCrossLinks` gap detection, tool-entry skip behavior)
- [x] `npm run build` — clean
- [x] Type check (`tsc --noEmit`) — no errors in editorial/reddit/youtube modules
- [x] Live YouTube API verified — fetched description for jWgCQDdsyrw, extracted correctly, revealed a real cross-link gap (the video description doesn't link to any blog post)
- [x] Live Reddit sync with Phase 6 YouTube matching — 4 previously-unmatched shares now correctly attributed to the YouTube entry, idempotent on re-run
- [x] All 8 Reddit submissions from /u/Middle-Feeling1313 are now tracked against their correct calendar entry (2 blog posts + 4 YouTube + 2 tool)
- [x] Code review performed; blocking finding addressed in `f98bf75`

## Known follow-ups (Phase 7)

- Tool cross-link audit — fetch tool page HTML, extract outbound links, detect missing backlinks to/from tools. Tracked in oletizi/audiocontrol.org#59

Closes oletizi/audiocontrol.org#57
