### PR TITLE
Phase 7: tool cross-link audit with cheerio HTML parsing

### DIFF
--- a/.claude/skills/editorial-cross-link-review/SKILL.md
+++ b/.claude/skills/editorial-cross-link-review/SKILL.md
@@ -13,8 +13,9 @@ For each Published calendar entry, check what it links to and whether those link
 1. **Read the calendar** via `readCalendar(process.cwd())`.
 2. **Build a blog-markdown loader**: given a slug, read `src/pages/blog/<slug>/index.md` and return its content. Return `null` on read errors.
 3. **Build a video-description loader**: given a `contentUrl`, call `getVideoMetadata(url)` from `scripts/lib/youtube/client.ts` and return the `description` field. Catch and swallow errors — return `null` for that entry instead, and let the audit record it.
-4. **Run the audit**: `auditCrossLinks({ calendar, fetchBlogMarkdown, fetchVideoDescription })` from `scripts/lib/editorial/crosslinks.ts`.
-5. **Report** the results using the format below.
+4. **Build a tool-page loader**: given a `contentUrl`, call `fetchHtml(url)` from `scripts/lib/http/fetch-page.ts` and return the response body. Catch and swallow errors — return `null` for that entry.
+5. **Run the audit**: `auditCrossLinks({ calendar, fetchBlogMarkdown, fetchVideoDescription, fetchToolPage })` from `scripts/lib/editorial/crosslinks.ts`.
+6. **Report** the results using the format below.
 
 ## Report Format
 
@@ -46,7 +47,9 @@ Group sections exactly as above. Omit any section that has no items. If everythi
 ## Important
 
 - **Read-only** — do not modify `docs/editorial-calendar.md` or any blog markdown files.
-- **Don't fail the whole audit on one bad fetch**: if the YouTube API errors for one video, record the error against that entry and move on. Users will want to see partial results.
-- **Unresolved outbound links** (a YouTube URL in a blog post that doesn't match any known video calendar entry) should prompt the user to consider adding it as a calendar entry — that's the main way Phase 6 expects the calendar to grow.
+- **Don't fail the whole audit on one bad fetch**: if the YouTube API errors for one video or the tool page fails to load, record the error against that entry and move on. Users will want to see partial results.
+- **Unresolved outbound links** (a YouTube URL in a blog post that doesn't match any known video calendar entry, or an audiocontrol.org URL that doesn't match any known entry) should prompt the user to consider adding it as a calendar entry — that's the main way the calendar grows.
 - **Blog entries without markdown files** should still report (as errors) — missing markdown usually means the blog post is tracked in the calendar but not yet written.
+- **Unified URL resolution**: YouTube URLs match by video ID (so `youtu.be/X` and `youtube.com/watch?v=X` resolve to the same entry); audiocontrol.org URLs match by canonical `contentUrl` (case-insensitive hostname, trailing-slash-normalized). Blog entries auto-derive their canonical URL from slug.
+- **Tool-page extraction uses cheerio** — robust to malformed HTML. `href`/`src` attributes and bare URLs in text are all captured; `<script>` and `<style>` contents are explicitly excluded.
 - If `~/.config/audiocontrol/youtube-key.txt` is missing, the skill throws with setup instructions from `scripts/lib/youtube/config.ts`. No silent degradation.

--- a/docs/1.0/001-IN-PROGRESS/editorial-calendar/README.md
+++ b/docs/1.0/001-IN-PROGRESS/editorial-calendar/README.md
@@ -19,7 +19,7 @@ Structured editorial calendar that tracks content through its lifecycle (idea th
 | 4 | Social Distribution Tracking | Complete |
 | 5 | Subreddit Tracking & Cross-posting Opportunities | Ready to ship |
 | 6 | YouTube as First-Class Content + Cross-link Audit | In Progress |
-| 7 | Tool Cross-link Audit | Pending (starts after Phase 6 merges) |
+| 7 | Tool Cross-link Audit | In Progress |
 
 ## Dependencies
 

--- a/docs/1.0/001-IN-PROGRESS/editorial-calendar/workplan.md
+++ b/docs/1.0/001-IN-PROGRESS/editorial-calendar/workplan.md
@@ -154,15 +154,15 @@
 
 #### Data model
 
-- [ ] Add `channel?: string` field to `DistributionRecord` (e.g. `r/synthdiy`, YouTube channel handle, LinkedIn page slug)
-- [ ] Add `topics?: string[]` to `CalendarEntry` (optional — overlaps with `targetKeywords` but is semantically distinct: topics are coarse tags used for cross-posting recommendations, keywords are SEO targets)
-- [ ] Extend the Distribution markdown table with a Channel column; maintain backwards-compat parsing for old rows without the column
+- [x] Add `channel?: string` field to `DistributionRecord` (e.g. `r/synthdiy`, YouTube channel handle, LinkedIn page slug)
+- [x] Add `topics?: string[]` to `CalendarEntry` (optional — overlaps with `targetKeywords` but is semantically distinct: topics are coarse tags used for cross-posting recommendations, keywords are SEO targets)
+- [x] Extend the Distribution markdown table with a Channel column; maintain backwards-compat parsing for old rows without the column
 
 #### Curated map
 
-- [ ] Create `docs/editorial-channels.json` with a `topic → [subreddit]` map (JSON rather than YAML to avoid a new dependency; human-editable enough for a curated list)
-- [ ] Seed the map with topic tags we'll use for audiocontrol.org content: `samplers`, `vintage-hardware`, `scsi`, `roland`, `akai`, `ai-agents`, `home-studio`, etc. (initial set — user to curate)
-- [ ] Each subreddit entry can carry optional hints (self-promo rules, flair requirements) as free-form notes
+- [x] Create `docs/editorial-channels.json` with a `topic → [subreddit]` map (JSON rather than YAML to avoid a new dependency; human-editable enough for a curated list)
+- [x] Seed the map with topic tags we'll use for audiocontrol.org content: `samplers`, `vintage-hardware`, `scsi`, `roland`, `akai`, `ai-agents`, `home-studio`, etc. (initial set — user to curate)
+- [x] Each subreddit entry can carry optional hints (self-promo rules, flair requirements) as free-form notes
 
 #### Implementation
 
@@ -268,9 +268,9 @@ No new user-invocable skill beyond `/editorial-cross-link-review`. The rest are 
 
 #### Data model
 
-- [ ] Add `contentType: 'blog' | 'youtube'` to `CalendarEntry` (optional during parsing, defaults to `'blog'` — all existing entries remain valid)
-- [ ] Add `contentUrl?: string` to `CalendarEntry` — the canonical URL for content that doesn't live at `/blog/<slug>/`. For blog entries, stays unset (URL is derived from slug). For YouTube entries, stores the full YouTube URL
-- [ ] Extend `calendar.ts` parser/writer: stage tables gain optional `Type` and `URL` columns, emitted only when any entry in the stage has a non-default value (same pattern as Phase 5's Topics/Channel columns)
+- [x] Add `contentType: 'blog' | 'youtube' | 'tool'` to `CalendarEntry` (optional during parsing, defaults to `'blog'` — all existing entries remain valid; `tool` added in Phase 6 to cover standalone apps)
+- [x] Add `contentUrl?: string` to `CalendarEntry` — the canonical URL for content that doesn't live at `/blog/<slug>/`. For blog entries, stays unset (URL is derived from slug). For YouTube/tool entries, stores the full URL
+- [x] Extend `calendar.ts` parser/writer: stage tables gain optional `Type` and `URL` columns, emitted only when any entry in the stage has a non-default value (same pattern as Phase 5's Topics/Channel columns)
 
 #### Curated map
 
@@ -300,7 +300,7 @@ No changes — `editorial-channels.json` stays topic-to-subreddit. A YouTube vid
 **Reddit sync improvement**
 
 - [x] Update `/editorial-reddit-sync` to match submissions against `contentUrl` for YouTube entries in addition to blog URLs
-- [ ] Re-run the sync after Phase 6 ships, once the S-330 editor video exists as a calendar entry, to attribute the 6 pre-existing shares
+- [x] Re-run the sync after Phase 6 ships, once the S-330 editor video exists as a calendar entry, to attribute the 6 pre-existing shares (done in commit 9b9a701 + 00dd9bd — all 8 Reddit submissions now attributed)
 
 **Tests**
 

--- a/docs/1.0/001-IN-PROGRESS/editorial-calendar/workplan.md
+++ b/docs/1.0/001-IN-PROGRESS/editorial-calendar/workplan.md
@@ -356,45 +356,45 @@ No new user-invocable skill. `/editorial-cross-link-review` is extended: when it
 
 **HTML fetching**
 
-- [ ] `scripts/lib/http/fetch-page.ts` — minimal `fetchHtml(url)` returning the response body as text. Sets a descriptive User-Agent (e.g. `audiocontrol.org-editorial-calendar/1.0 cross-link-audit`), follows redirects, throws on non-2xx. No auth — these are public pages
-- [ ] Timeout: 10s. Tool pages are small and live on the same Netlify deploy; anything slower than 10s means the page is broken
-- [ ] No caching layer in this phase — cross-link audit is fast enough that a repeat fetch is fine. If it becomes an issue later, add a response cache keyed on URL
+- [x] `scripts/lib/http/fetch-page.ts` — `fetchHtml(url)` with descriptive User-Agent, 10s timeout via AbortController, throws on non-2xx. No auth
+- [x] No caching layer in this phase (revisit if audits get slow)
 
 **Link extraction**
 
-- [ ] `extractLinksFromHtml(html): string[]` in `crosslinks.ts` — regex-based extraction of `href="..."` / `href='...'` attributes and bare `https?://` URLs from the body. Returns absolute URLs, resolving relative `href`s against a base if one is passed in
-- [ ] Skip anchor-only links (`#section`), mail links (`mailto:`), and obvious non-content URLs (feeds, robots.txt, sitemap)
-- [ ] Unit tests against fixture Astro-built HTML — representative samples saved under `test/fixtures/tool-page.html`
+- [x] `extractLinksFromHtml(html, baseUrl?)` in `crosslinks.ts` — uses **cheerio** (the de-facto Node HTML parser, 30k+ stars, backed by htmlparser2) for robust DOM traversal. Regex parsing was considered and rejected — real HTML is too quirky
+- [x] Extracts `href`/`src` attributes plus bare URLs from text content; explicitly strips `<script>` and `<style>` before scanning
+- [x] Skips anchor-only, `mailto:`/`tel:`/`javascript:`/`data:`, feeds, sitemap, robots.txt
+- [x] Unit tests against realistic and deliberately garbage HTML
 
 **Generalized link resolution**
 
-- [ ] Build a unified `byContentUrl: Map<string, CalendarEntry>` index in `auditCrossLinks`: for each Published entry, compute its canonical URL — `audiocontrol.org/blog/<slug>/` for blog entries, `contentUrl` for YouTube/tool entries — and add it to the map. Normalize by stripping trailing slashes and case-insensitive hostname
-- [ ] Replace the current `extractBlogLinksFromDescription` callers' resolution logic with the unified index so tool URLs resolve from YouTube descriptions too (currently they're silently dropped)
+- [x] Unified `byContentUrl` index built from all Published entries. Blog entries derive canonical URL from slug; youtube/tool use `contentUrl`. Normalized via `canonicalizeUrl` (lowercase hostname, strip trailing slash, preserve query)
+- [x] `resolveUrl` tries YouTube first (video ID match — more robust than URL match for YouTube's many URL shapes), then falls back to `byContentUrl`
+- [x] `extractBlogLinksFromDescription` generalized to `extractAudioControlLinksFromText` — matches any audiocontrol.org URL, not just `/blog/`
+- [x] New `extractAudioControlLinksFromMarkdown` — catches absolute URLs AND markdown-relative links like `[text](/roland/s330/editor)`
 
 **Tool-entry audit branch**
 
-- [ ] In `auditCrossLinks`, when encountering a tool entry:
-  - Fetch `entry.contentUrl` via `fetchHtml`
-  - Extract links with `extractLinksFromHtml`
-  - For each extracted link, resolve against the unified `byContentUrl` index; record as `OutboundLink { resolvedSlug, resolved }`
-  - On fetch failure, record an error and move on (same per-entry-error pattern as the YouTube branch)
-- [ ] Remove the Phase 6 "tool entries are tracked but the audit doesn't analyze them" skip
+- [x] `auditCrossLinks` now has a tool branch: fetches `entry.contentUrl`, extracts links, resolves each via unified index
+- [x] Self-links filtered at the recording step (tool pages link to themselves via nav)
+- [x] On fetch failure, error recorded per-entry; audit continues
+- [x] Phase 6 "tool entries are tracked but not analyzed" skip removed
 
 **Reciprocation rules**
 
-- [ ] Same second-pass logic — if blog X links to tool Y and Y doesn't link back, flag it in Y's `missingBacklinksTo`; same in the other direction
-- [ ] Remove the Phase 6 second-pass tool-skip now that tools do have outbound links
+- [x] Phase 6 second-pass tool-skip removed — tools now have outbound links, reciprocation is meaningful
+- [x] Second pass unchanged in shape; flags missing backlinks in both directions
 
 **Skill update**
 
-- [ ] `/editorial-cross-link-review` skill doc updated to describe tool-page analysis and the fact that tool URLs are now resolvable targets from other entries' content
+- [x] `/editorial-cross-link-review` skill doc updated with tool-page fetching, unified resolution, cheerio note
 
 **Tests**
 
-- [ ] `extractLinksFromHtml` against fixture HTML covering `<a href="...">`, bare URLs in text, relative hrefs (ignored or resolved), anchor-only ignored, `mailto:` ignored
-- [ ] Unified `byContentUrl` index resolves all three content types correctly
-- [ ] `auditCrossLinks` with a tool entry + mock `fetchHtml` returning fixture HTML — verifies outbound extraction and reciprocation
-- [ ] End-to-end fixture: a calendar with a blog entry linking to a tool, a tool page linking back (or not) — both reciprocation states tested
+- [x] `extractLinksFromHtml` fixtures: realistic HTML, relative URLs, anchor/mailto/javascript skipping, feeds/sitemap/robots skipping, script/style exclusion, unclosed-tag tolerance, deduplication
+- [x] `extractAudioControlLinksFromMarkdown` with absolute + markdown-relative forms
+- [x] `canonicalizeUrl` cases (hostname case, trailing slash, query preservation)
+- [x] `auditCrossLinks` tool-entry tests: outbound extraction, blog-to-tool via relative link, missing-backlink detection, fetch failure per-entry, missing-contentUrl errors, self-link exclusion
 
 **Acceptance Criteria**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@playwright/test": "^1.58.2",
         "chart.js": "^4.5.1",
         "chartjs-node-canvas": "^5.0.0",
+        "cheerio": "^1.2.0",
         "openai": "^6.34.0",
         "satori": "^0.19.1",
         "sharp": "^0.34.5",
@@ -5094,6 +5095,50 @@
         "chart.js": "^4.4.8"
       }
     },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/chokidar": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
@@ -6135,6 +6180,20 @@
       "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
       "license": "MIT"
     },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -7148,6 +7207,39 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -7184,6 +7276,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ieee754": {
@@ -9545,6 +9650,33 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
@@ -10456,6 +10588,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/satori": {
       "version": "0.19.1",
@@ -11815,6 +11954,16 @@
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
       "license": "MIT"
     },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
@@ -12442,6 +12591,30 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -20,9 +20,10 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",
-    "openai": "^6.34.0",
     "chart.js": "^4.5.1",
     "chartjs-node-canvas": "^5.0.0",
+    "cheerio": "^1.2.0",
+    "openai": "^6.34.0",
     "satori": "^0.19.1",
     "sharp": "^0.34.5",
     "tsx": "^4.21.0",

--- a/scripts/lib/editorial/crosslinks.ts
+++ b/scripts/lib/editorial/crosslinks.ts
@@ -1,66 +1,148 @@
 /**
- * Cross-link audit between blog posts and YouTube videos.
+ * Cross-link audit across all three calendar content types.
  *
- * Closes the loop: for each Published entry, what does it link to, which
- * of those links resolve to known calendar entries, and which don't
- * reciprocate? The audit is bidirectional — a gap is "blog X links to
- * video Y, but Y's description doesn't link back to X" OR vice versa.
+ * For each Published entry, what does it link to, which of those links
+ * resolve to known calendar entries, and which don't reciprocate?
  *
- * This module does no I/O on its own. It's given:
- *  - the calendar (entries in memory)
- *  - the blog MD content for each blog entry (read by the caller)
- *  - a `fetchDescription(url)` closure that returns the YouTube video
- *    description (caller wires this to YouTube Data API or a fixture)
+ *   blog    → parse MD for YouTube URLs + audiocontrol.org URLs
+ *   youtube → parse description (fetched) for audiocontrol.org URLs
+ *   tool    → parse page HTML (fetched) for any outbound URL
  *
- * Keeping I/O at the edges makes the audit testable and lets callers
- * swap in fixtures for tests or the live YouTube client in the skill.
+ * All URLs get resolved through a unified index: YouTube URLs match by
+ * video ID; audiocontrol.org URLs match by canonical `contentUrl`.
+ *
+ * I/O is injected at the edges so tests use fixtures and the live skill
+ * wires in the YouTube client and the HTML fetcher.
  */
 
-import { effectiveContentType, type CalendarEntry, type EditorialCalendar } from './types.js';
+import { load as cheerioLoad } from 'cheerio';
+import {
+  effectiveContentType,
+  type CalendarEntry,
+  type EditorialCalendar,
+} from './types.js';
 import { extractVideoId } from '../youtube/client.js';
 
+// ---------------------------------------------------------------------------
+// Link extraction
+// ---------------------------------------------------------------------------
+
 /**
- * Find YouTube URLs in a blog post's markdown body.
- *
- * Captures:
- *  - plain `https://www.youtube.com/watch?v=...` and `https://youtu.be/...`
- *  - shorts `https://www.youtube.com/shorts/...`
- *  - `<iframe src="https://www.youtube.com/embed/...">` embeds
+ * Find YouTube URLs in blog post markdown.
+ * Captures watch / youtu.be / shorts / embed forms.
  */
 export function extractYouTubeLinksFromMarkdown(md: string): string[] {
   const urls = new Set<string>();
-
   const patterns: RegExp[] = [
-    // youtube.com/watch?v=ID (URL, not necessarily inside a link)
     /https?:\/\/(?:www\.|m\.)?youtube\.com\/watch\?[^\s"')]*v=[A-Za-z0-9_-]{11}[^\s"')]*/gi,
-    // youtu.be/ID
     /https?:\/\/youtu\.be\/[A-Za-z0-9_-]{11}[^\s"')]*/gi,
-    // youtube.com/shorts/ID
     /https?:\/\/(?:www\.)?youtube\.com\/shorts\/[A-Za-z0-9_-]{11}[^\s"')]*/gi,
-    // youtube.com/embed/ID (inside iframe src)
     /https?:\/\/(?:www\.)?youtube\.com\/embed\/[A-Za-z0-9_-]{11}[^\s"')]*/gi,
   ];
-
   for (const pattern of patterns) {
-    const matches = md.matchAll(pattern);
-    for (const m of matches) urls.add(m[0]);
+    for (const m of md.matchAll(pattern)) urls.add(m[0]);
+  }
+  return [...urls];
+}
+
+/**
+ * Find any audiocontrol.org URL in a plain-text blob (YouTube descriptions,
+ * blog MD that uses full URLs, anywhere URLs appear in raw text).
+ *
+ * Replaces the Phase 6 `extractBlogLinksFromDescription`, which only
+ * matched `/blog/<slug>/` paths and silently dropped tool URLs.
+ */
+export function extractAudioControlLinksFromText(text: string): string[] {
+  const urls = new Set<string>();
+  const pattern = /https?:\/\/(?:www\.)?audiocontrol\.org\/[^\s"')\]<>]*/gi;
+  for (const m of text.matchAll(pattern)) urls.add(m[0]);
+  return [...urls];
+}
+
+/**
+ * Find audiocontrol.org URLs in blog markdown — both absolute URLs
+ * and markdown-link relative paths like `[text](/roland/s330/editor)`
+ * (which resolve to the site's own pages).
+ */
+export function extractAudioControlLinksFromMarkdown(md: string): string[] {
+  const urls = new Set<string>();
+
+  for (const url of extractAudioControlLinksFromText(md)) urls.add(url);
+
+  // [text](/path/...) — markdown link to a relative site path
+  const relativePattern = /\]\((\/[^\s)]+)\)/g;
+  for (const m of md.matchAll(relativePattern)) {
+    urls.add(`https://audiocontrol.org${m[1]}`);
   }
 
   return [...urls];
 }
 
 /**
- * Find audiocontrol.org blog URLs in a string (typically a YouTube video
- * description). Returns the full URL; the caller is responsible for
- * extracting the slug if needed.
+ * Extract outbound URLs from rendered HTML using cheerio — href, src,
+ * and bare URLs in text nodes. Resolves relative URLs against the
+ * provided base URL. Uses a real HTML parser so we're robust to
+ * malformed/unclosed/quirky markup from any source.
+ *
+ * Skips:
+ *   - anchor-only links (#section)
+ *   - mailto / tel / javascript / data schemes
+ *   - feeds (*.xml, *.rss, *.atom), sitemap.xml, robots.txt
+ *   - script and style contents (quoted URLs in inline JS shouldn't count as outbound links)
  */
-export function extractBlogLinksFromDescription(desc: string): string[] {
-  const urls = new Set<string>();
-  const pattern =
-    /https?:\/\/(?:www\.)?audiocontrol\.org\/blog\/[a-z0-9-]+\/?/gi;
-  const matches = desc.matchAll(pattern);
-  for (const m of matches) urls.add(m[0]);
-  return [...urls];
+export function extractLinksFromHtml(html: string, baseUrl?: string): string[] {
+  const $ = cheerioLoad(html);
+
+  // Remove script and style before scanning text so their contents don't leak in
+  $('script, style, noscript').remove();
+
+  const raw = new Set<string>();
+
+  $('a[href], link[href], area[href]').each((_, el) => {
+    const href = $(el).attr('href');
+    if (href) raw.add(href);
+  });
+
+  $('img[src], iframe[src], video[src], source[src], audio[src], embed[src]').each((_, el) => {
+    const src = $(el).attr('src');
+    if (src) raw.add(src);
+  });
+
+  // Bare URLs in text content (e.g. a plain URL typed into a paragraph)
+  const bareUrlPattern = /https?:\/\/[^\s<>"')]+/gi;
+  const textContent = $.root().text();
+  for (const m of textContent.matchAll(bareUrlPattern)) raw.add(m[0]);
+
+  const base = baseUrl ? safeParseUrl(baseUrl) : undefined;
+  const absolute = new Set<string>();
+
+  for (const candidate of raw) {
+    const trimmed = candidate.trim();
+    if (!trimmed) continue;
+    if (trimmed.startsWith('#')) continue;
+    if (/^(mailto|tel|javascript|data):/i.test(trimmed)) continue;
+
+    let resolved: string | null = null;
+    if (/^https?:\/\//i.test(trimmed)) {
+      resolved = trimmed;
+    } else if (base) {
+      try {
+        resolved = new URL(trimmed, base).toString();
+      } catch {
+        continue;
+      }
+    } else {
+      continue;
+    }
+
+    if (/\.(xml|rss|atom)(\?|$)/i.test(resolved)) continue;
+    if (/\/sitemap(-index)?\.xml/i.test(resolved)) continue;
+    if (/\/robots\.txt(\?|$)/i.test(resolved)) continue;
+
+    absolute.add(resolved);
+  }
+
+  return [...absolute];
 }
 
 /** Extract the slug from an audiocontrol.org/blog/ URL. */
@@ -71,31 +153,90 @@ export function slugFromBlogUrl(url: string): string | null {
   return match ? match[1] : null;
 }
 
+// ---------------------------------------------------------------------------
+// URL resolution
+// ---------------------------------------------------------------------------
+
+function safeParseUrl(value: string): URL | null {
+  try {
+    return new URL(value);
+  } catch {
+    return null;
+  }
+}
+
 /**
- * One outbound link found in a calendar entry's content, resolved against
- * the calendar so we can report whether the target is tracked.
+ * Normalize a URL for comparison: lowercase hostname, strip trailing
+ * slash from the path (except for root), drop fragment. Preserves query
+ * string so distinct endpoints don't collide.
  */
+export function canonicalizeUrl(url: string): string {
+  const u = safeParseUrl(url);
+  if (!u) return url.trim().toLowerCase();
+  let path = u.pathname.replace(/\/+$/, '');
+  if (path === '') path = '/';
+  const query = u.search;
+  return `${u.protocol}//${u.hostname.toLowerCase()}${path}${query}`;
+}
+
+function buildByContentUrl(entries: CalendarEntry[]): Map<string, CalendarEntry> {
+  const map = new Map<string, CalendarEntry>();
+  for (const e of entries) {
+    const type = effectiveContentType(e);
+    const url =
+      type === 'blog'
+        ? `https://audiocontrol.org/blog/${e.slug}/`
+        : e.contentUrl;
+    if (!url) continue;
+    map.set(canonicalizeUrl(url), e);
+  }
+  return map;
+}
+
+function buildByVideoId(entries: CalendarEntry[]): Map<string, CalendarEntry> {
+  const map = new Map<string, CalendarEntry>();
+  for (const e of entries) {
+    if (effectiveContentType(e) !== 'youtube' || !e.contentUrl) continue;
+    try {
+      map.set(extractVideoId(e.contentUrl), e);
+    } catch {
+      // contentUrl present but not a recognizable YouTube URL — skip indexing
+    }
+  }
+  return map;
+}
+
+function resolveUrl(
+  url: string,
+  byVideoId: Map<string, CalendarEntry>,
+  byContentUrl: Map<string, CalendarEntry>,
+): CalendarEntry | null {
+  // YouTube: video ID is more robust than URL match (handles youtu.be,
+  // watch?v=, shorts/, embed/ all as one target)
+  try {
+    const id = extractVideoId(url);
+    const hit = byVideoId.get(id);
+    if (hit) return hit;
+  } catch {
+    // not a YouTube URL
+  }
+  return byContentUrl.get(canonicalizeUrl(url)) ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Audit
+// ---------------------------------------------------------------------------
+
 export interface OutboundLink {
-  /** Raw URL as it appears in the source content */
   url: string;
-  /** Slug of the calendar entry this link points to, if any */
   resolvedSlug: string | null;
-  /** Whether the target entry exists in the calendar */
   resolved: boolean;
 }
 
-/** The audit result for a single calendar entry. */
 export interface EntryAudit {
   entry: CalendarEntry;
-  /** Links found in this entry's content */
   outbound: OutboundLink[];
-  /**
-   * Slugs of other entries that link to this one but are not reciprocated —
-   * i.e. other entries where `outbound` includes this entry's slug but this
-   * entry's `outbound` doesn't include theirs.
-   */
   missingBacklinksTo: string[];
-  /** Free-form errors encountered during the audit for this entry (e.g. fetch failed). */
   errors: string[];
 }
 
@@ -105,9 +246,10 @@ export interface AuditCrossLinksInput {
   fetchBlogMarkdown: (slug: string) => string | null;
   /** Fetch a YouTube video's description by the contentUrl. Returns null on failure. */
   fetchVideoDescription: (contentUrl: string) => Promise<string | null>;
+  /** Fetch a tool page's HTML by the contentUrl. Returns null on failure. */
+  fetchToolPage: (contentUrl: string) => Promise<string | null>;
 }
 
-/** The complete audit report. */
 export interface AuditReport {
   entries: EntryAudit[];
 }
@@ -115,44 +257,43 @@ export interface AuditReport {
 /**
  * Run the cross-link audit against a calendar.
  *
- * Iterates Published entries, extracts outbound links from each, then
- * does a second pass to detect non-reciprocated links. Returns a report
- * with one EntryAudit per Published entry.
+ * First pass: per-entry outbound link extraction.
+ * Second pass: detect non-reciprocated links.
+ *
+ * O(entries × outbound²) in the second pass via the nested
+ * reciprocation check. Fine at our scale (tens of entries); revisit if
+ * the calendar grows past hundreds.
  */
 export async function auditCrossLinks(
   input: AuditCrossLinksInput,
 ): Promise<AuditReport> {
-  const { calendar, fetchBlogMarkdown, fetchVideoDescription } = input;
+  const { calendar, fetchBlogMarkdown, fetchVideoDescription, fetchToolPage } = input;
   const published = calendar.entries.filter((e) => e.stage === 'Published');
 
-  const bySlug = new Map<string, CalendarEntry>();
-  const byVideoId = new Map<string, CalendarEntry>();
-  for (const e of published) {
-    bySlug.set(e.slug, e);
-    if (effectiveContentType(e) === 'youtube' && e.contentUrl) {
-      try {
-        byVideoId.set(extractVideoId(e.contentUrl), e);
-      } catch {
-        // contentUrl is present but not a recognizable YouTube URL — skip indexing
-      }
-    }
-  }
+  const byVideoId = buildByVideoId(published);
+  const byContentUrl = buildByContentUrl(published);
 
-  // First pass: per-entry outbound links
+  const recordOutbound = (
+    outbound: OutboundLink[],
+    url: string,
+    selfSlug: string,
+  ): void => {
+    const target = resolveUrl(url, byVideoId, byContentUrl);
+    // Self-links don't count as outbound to another entry
+    if (target && target.slug === selfSlug) return;
+    outbound.push({
+      url,
+      resolvedSlug: target?.slug ?? null,
+      resolved: target !== null,
+    });
+  };
+
   const audits: EntryAudit[] = [];
+
   for (const entry of published) {
     const outbound: OutboundLink[] = [];
     const errors: string[] = [];
-
     const entryType = effectiveContentType(entry);
-
-    // Tool entries are tracked in the calendar but the cross-link audit
-    // doesn't analyze them yet: they have no MD file we own and no
-    // fetch-able description. Tool-audit support is a follow-up.
-    if (entryType === 'tool') {
-      audits.push({ entry, outbound: [], missingBacklinksTo: [], errors: [] });
-      continue;
-    }
 
     if (entryType === 'blog') {
       const md = fetchBlogMarkdown(entry.slug);
@@ -160,15 +301,10 @@ export async function auditCrossLinks(
         errors.push(`could not read blog markdown for ${entry.slug}`);
       } else {
         for (const url of extractYouTubeLinksFromMarkdown(md)) {
-          let resolvedSlug: string | null = null;
-          try {
-            const id = extractVideoId(url);
-            const target = byVideoId.get(id);
-            if (target) resolvedSlug = target.slug;
-          } catch {
-            // unparseable — treat as unresolved
-          }
-          outbound.push({ url, resolvedSlug, resolved: resolvedSlug !== null });
+          recordOutbound(outbound, url, entry.slug);
+        }
+        for (const url of extractAudioControlLinksFromMarkdown(md)) {
+          recordOutbound(outbound, url, entry.slug);
         }
       }
     } else if (entryType === 'youtube') {
@@ -180,19 +316,28 @@ export async function auditCrossLinks(
           desc = await fetchVideoDescription(entry.contentUrl);
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
-          errors.push(
-            `fetching description for ${entry.slug}: ${message}`,
-          );
+          errors.push(`fetching description for ${entry.slug}: ${message}`);
         }
         if (desc !== null) {
-          for (const url of extractBlogLinksFromDescription(desc)) {
-            const slug = slugFromBlogUrl(url);
-            const resolvedSlug = slug && bySlug.has(slug) ? slug : null;
-            outbound.push({
-              url,
-              resolvedSlug,
-              resolved: resolvedSlug !== null,
-            });
+          for (const url of extractAudioControlLinksFromText(desc)) {
+            recordOutbound(outbound, url, entry.slug);
+          }
+        }
+      }
+    } else if (entryType === 'tool') {
+      if (!entry.contentUrl) {
+        errors.push(`Tool entry ${entry.slug} has no contentUrl`);
+      } else {
+        let html: string | null = null;
+        try {
+          html = await fetchToolPage(entry.contentUrl);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          errors.push(`fetching tool page for ${entry.slug}: ${message}`);
+        }
+        if (html !== null) {
+          for (const url of extractLinksFromHtml(html, entry.contentUrl)) {
+            recordOutbound(outbound, url, entry.slug);
           }
         }
       }
@@ -201,9 +346,8 @@ export async function auditCrossLinks(
     audits.push({ entry, outbound, missingBacklinksTo: [], errors });
   }
 
-  // Second pass: detect missing backlinks. For each audit A, find every
-  // audit B where B.outbound resolves to A.entry.slug but A.outbound does
-  // NOT resolve to B.entry.slug. Add B's slug to A.missingBacklinksTo.
+  // Second pass: if B.outbound resolves to A, but A.outbound doesn't
+  // resolve to B, flag on A.missingBacklinksTo.
   const auditBySlug = new Map<string, EntryAudit>();
   for (const a of audits) auditBySlug.set(a.entry.slug, a);
 
@@ -212,10 +356,6 @@ export async function auditCrossLinks(
       if (!link.resolvedSlug) continue;
       const a = auditBySlug.get(link.resolvedSlug);
       if (!a) continue;
-      // Tool entries are not audited for outbound links, so reciprocation
-      // isn't meaningful — skip to avoid false-positive "missing backlink"
-      // flags against every tool.
-      if (effectiveContentType(a.entry) === 'tool') continue;
       const reciprocated = a.outbound.some(
         (l) => l.resolvedSlug === b.entry.slug,
       );

--- a/scripts/lib/editorial/crosslinks.ts
+++ b/scripts/lib/editorial/crosslinks.ts
@@ -169,6 +169,14 @@ function safeParseUrl(value: string): URL | null {
  * Normalize a URL for comparison: lowercase hostname, strip trailing
  * slash from the path (except for root), drop fragment. Preserves query
  * string so distinct endpoints don't collide.
+ *
+ * Input is expected to already be an http(s) URL — callers get URLs from
+ * the extractor functions which filter out non-URL candidates upstream.
+ * If we encounter an unparseable string anyway (e.g. a weird attribute
+ * value cheerio surfaced), we return a best-effort lowercase-trimmed
+ * form so callers don't crash. The resulting key won't match anything
+ * real in `byContentUrl`, which is the right behavior: an unparseable
+ * URL shouldn't resolve to any calendar entry.
  */
 export function canonicalizeUrl(url: string): string {
   const u = safeParseUrl(url);

--- a/scripts/lib/editorial/index.ts
+++ b/scripts/lib/editorial/index.ts
@@ -44,8 +44,11 @@ export {
 
 export {
   extractYouTubeLinksFromMarkdown,
-  extractBlogLinksFromDescription,
+  extractAudioControlLinksFromText,
+  extractAudioControlLinksFromMarkdown,
+  extractLinksFromHtml,
   slugFromBlogUrl,
+  canonicalizeUrl,
   auditCrossLinks,
   type OutboundLink,
   type EntryAudit,

--- a/scripts/lib/http/fetch-page.ts
+++ b/scripts/lib/http/fetch-page.ts
@@ -1,0 +1,71 @@
+/**
+ * Minimal HTML fetcher for public pages.
+ *
+ * Used by the cross-link audit to fetch rendered tool pages from
+ * audiocontrol.org. No auth, follows redirects (built into `fetch`),
+ * throws on non-2xx so callers can record the error per-entry without
+ * silent corruption.
+ *
+ * Sets a descriptive User-Agent so we're identifiable in the Netlify
+ * access log if anything odd shows up.
+ */
+
+const DEFAULT_USER_AGENT =
+  'audiocontrol.org-editorial-calendar/1.0 cross-link-audit';
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+export interface FetchHtmlOptions {
+  /** Override the User-Agent header. */
+  userAgent?: string;
+  /** Abort the request after this many ms. Default 10s. */
+  timeoutMs?: number;
+}
+
+/**
+ * Fetch a public HTML page and return its body as a string.
+ *
+ * Throws with a specific message on:
+ *  - non-2xx responses (status + URL)
+ *  - timeout after the configured budget
+ *  - network errors (wrapped with the URL for context)
+ */
+export async function fetchHtml(
+  url: string,
+  options: FetchHtmlOptions = {},
+): Promise<string> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const userAgent = options.userAgent ?? DEFAULT_USER_AGENT;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(url, {
+      headers: {
+        'User-Agent': userAgent,
+        Accept: 'text/html,application/xhtml+xml',
+      },
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `fetchHtml: ${response.status} ${response.statusText} for ${url}`,
+      );
+    }
+
+    return await response.text();
+  } catch (err) {
+    if (err instanceof Error && err.name === 'AbortError') {
+      throw new Error(`fetchHtml: timeout after ${timeoutMs}ms for ${url}`);
+    }
+    if (err instanceof Error && err.message.startsWith('fetchHtml:')) {
+      throw err;
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`fetchHtml: ${message} for ${url}`);
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/scripts/lib/http/index.ts
+++ b/scripts/lib/http/index.ts
@@ -1,0 +1,1 @@
+export { fetchHtml, type FetchHtmlOptions } from './fetch-page.js';

--- a/test/editorial/phase6.test.ts
+++ b/test/editorial/phase6.test.ts
@@ -17,7 +17,7 @@ import {
 } from '../../scripts/lib/editorial/index.js';
 import {
   auditCrossLinks,
-  extractBlogLinksFromDescription,
+  extractAudioControlLinksFromText,
   extractYouTubeLinksFromMarkdown,
   slugFromBlogUrl,
 } from '../../scripts/lib/editorial/crosslinks.js';
@@ -185,22 +185,24 @@ Again: https://youtu.be/abcdefghijk
   });
 });
 
-describe('extractBlogLinksFromDescription', () => {
-  it('extracts audiocontrol.org/blog/ URLs', () => {
+describe('extractAudioControlLinksFromText', () => {
+  it('extracts any audiocontrol.org URL', () => {
     const desc = `
 Full article: https://audiocontrol.org/blog/scsi-over-wifi-raspberry-pi-bridge/
 
-Also see: https://www.audiocontrol.org/blog/roland-s-series-samplers
+Try the tool: https://audiocontrol.org/roland/s330/editor
+
+Also: https://www.audiocontrol.org/blog/roland-s-series-samplers
 `;
-    const urls = extractBlogLinksFromDescription(desc);
-    expect(urls).toHaveLength(2);
+    const urls = extractAudioControlLinksFromText(desc);
+    expect(urls).toHaveLength(3);
     expect(urls).toContain('https://audiocontrol.org/blog/scsi-over-wifi-raspberry-pi-bridge/');
+    expect(urls).toContain('https://audiocontrol.org/roland/s330/editor');
     expect(urls).toContain('https://www.audiocontrol.org/blog/roland-s-series-samplers');
   });
 
-  it('ignores audiocontrol.org URLs that are not /blog/', () => {
-    const desc = 'https://audiocontrol.org/roland/s330/editor';
-    expect(extractBlogLinksFromDescription(desc)).toEqual([]);
+  it('returns empty when no audiocontrol.org URLs are present', () => {
+    expect(extractAudioControlLinksFromText('no links here')).toEqual([]);
   });
 });
 
@@ -242,6 +244,7 @@ describe('auditCrossLinks', () => {
       fetchBlogMarkdown: (slug) => blogBodies[slug] ?? null,
       fetchVideoDescription: async () =>
         'Read more at https://audiocontrol.org/blog/s330-post/',
+      fetchToolPage: async () => null,
     });
     const postAudit = report.entries.find((a) => a.entry.slug === 's330-post');
     const videoAudit = report.entries.find((a) => a.entry.slug === 's330-video');
@@ -256,6 +259,7 @@ describe('auditCrossLinks', () => {
       calendar,
       fetchBlogMarkdown: (slug) => blogBodies[slug] ?? null,
       fetchVideoDescription: async () => 'No blog links here.',
+      fetchToolPage: async () => null,
     });
     const videoAudit = report.entries.find((a) => a.entry.slug === 's330-video');
     // The blog post links TO the video but the video does NOT link BACK to the post.
@@ -268,6 +272,7 @@ describe('auditCrossLinks', () => {
       calendar,
       fetchBlogMarkdown: () => null,
       fetchVideoDescription: async () => '',
+      fetchToolPage: async () => null,
     });
     const postAudit = report.entries.find((a) => a.entry.slug === 's330-post');
     expect(postAudit?.errors.length).toBeGreaterThan(0);
@@ -294,6 +299,7 @@ describe('auditCrossLinks', () => {
       calendar: cal,
       fetchBlogMarkdown: () => null,
       fetchVideoDescription: async () => '',
+      fetchToolPage: async () => null,
     });
     const toolAudit = report.entries.find((a) => a.entry.slug === 's330-editor');
     expect(toolAudit?.outbound).toEqual([]);
@@ -321,6 +327,7 @@ describe('auditCrossLinks', () => {
       calendar: cal,
       fetchBlogMarkdown: () => null,
       fetchVideoDescription: async () => '',
+      fetchToolPage: async () => null,
     });
     expect(report.entries[0].errors.join(' ')).toMatch(/no contentUrl/);
   });

--- a/test/editorial/phase7.test.ts
+++ b/test/editorial/phase7.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Unit tests for Phase 7 additions:
+ * - extractLinksFromHtml (cheerio-based, tolerant of malformed HTML)
+ * - extractAudioControlLinksFromMarkdown (markdown-relative + absolute)
+ * - canonicalizeUrl
+ * - auditCrossLinks with tool entries: fetches page, extracts links,
+ *   resolves against unified byContentUrl index
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  auditCrossLinks,
+  canonicalizeUrl,
+  extractAudioControlLinksFromMarkdown,
+  extractLinksFromHtml,
+  type CalendarEntry,
+  type EditorialCalendar,
+} from '../../scripts/lib/editorial/index.js';
+
+describe('extractLinksFromHtml (cheerio)', () => {
+  it('extracts href, src, and bare URLs', () => {
+    const html = `
+      <html><body>
+        <a href="https://audiocontrol.org/blog/foo/">Foo</a>
+        <iframe src="https://www.youtube.com/embed/abcdefghijk"></iframe>
+        <p>Also see https://example.com/other for more.</p>
+      </body></html>
+    `;
+    const urls = extractLinksFromHtml(html);
+    expect(urls).toContain('https://audiocontrol.org/blog/foo/');
+    expect(urls).toContain('https://www.youtube.com/embed/abcdefghijk');
+    expect(urls).toContain('https://example.com/other');
+  });
+
+  it('resolves relative URLs against the base URL', () => {
+    const html = '<a href="/roland/s330/editor">Editor</a>';
+    const urls = extractLinksFromHtml(html, 'https://audiocontrol.org/');
+    expect(urls).toContain('https://audiocontrol.org/roland/s330/editor');
+  });
+
+  it('skips anchor-only, mailto, and javascript links', () => {
+    const html = `
+      <a href="#section">Jump</a>
+      <a href="mailto:me@example.com">Mail</a>
+      <a href="javascript:void(0)">Do</a>
+      <a href="https://audiocontrol.org/blog/keep/">Keep</a>
+    `;
+    const urls = extractLinksFromHtml(html, 'https://audiocontrol.org/');
+    expect(urls).toEqual(['https://audiocontrol.org/blog/keep/']);
+  });
+
+  it('skips feeds, sitemaps, and robots.txt', () => {
+    const html = `
+      <link rel="alternate" href="/rss.xml" />
+      <a href="/sitemap-index.xml">Sitemap</a>
+      <a href="/robots.txt">Robots</a>
+      <a href="https://audiocontrol.org/blog/keep/">Keep</a>
+    `;
+    const urls = extractLinksFromHtml(html, 'https://audiocontrol.org/');
+    expect(urls).toEqual(['https://audiocontrol.org/blog/keep/']);
+  });
+
+  it('does not extract URLs from inside <script> or <style>', () => {
+    const html = `
+      <script>const pixel = "https://tracker.example.com/pixel.gif";</script>
+      <style>a.blog { background: url(https://tracker.example.com/bg.png); }</style>
+      <a href="https://audiocontrol.org/blog/real-link/">Real</a>
+    `;
+    const urls = extractLinksFromHtml(html, 'https://audiocontrol.org/');
+    expect(urls).toContain('https://audiocontrol.org/blog/real-link/');
+    expect(urls.some((u) => u.includes('tracker.example.com'))).toBe(false);
+  });
+
+  it('tolerates unclosed tags and garbage markup', () => {
+    const html = `
+      <p>Lorem <a href="https://audiocontrol.org/blog/foo/">foo<p>
+      <a href='https://audiocontrol.org/blog/bar/'>bar
+      <iframe src="https://www.youtube.com/embed/aaaaaaaaaaa">
+      <div>unclosed
+    `;
+    const urls = extractLinksFromHtml(html, 'https://audiocontrol.org/');
+    expect(urls).toContain('https://audiocontrol.org/blog/foo/');
+    expect(urls).toContain('https://audiocontrol.org/blog/bar/');
+    expect(urls).toContain('https://www.youtube.com/embed/aaaaaaaaaaa');
+  });
+
+  it('deduplicates the same URL appearing multiple times', () => {
+    const html = `
+      <a href="https://audiocontrol.org/blog/foo/">One</a>
+      <a href="https://audiocontrol.org/blog/foo/">Two</a>
+    `;
+    const urls = extractLinksFromHtml(html);
+    expect(urls.filter((u) => u === 'https://audiocontrol.org/blog/foo/')).toHaveLength(1);
+  });
+});
+
+describe('extractAudioControlLinksFromMarkdown', () => {
+  it('extracts absolute audiocontrol.org URLs', () => {
+    const md = `See https://audiocontrol.org/blog/foo/ for details.`;
+    expect(extractAudioControlLinksFromMarkdown(md)).toEqual([
+      'https://audiocontrol.org/blog/foo/',
+    ]);
+  });
+
+  it('extracts markdown-style relative links to site paths', () => {
+    const md = `Try the [S-330 editor](/roland/s330/editor) or [blog post](/blog/foo/).`;
+    const urls = extractAudioControlLinksFromMarkdown(md);
+    expect(urls).toContain('https://audiocontrol.org/roland/s330/editor');
+    expect(urls).toContain('https://audiocontrol.org/blog/foo/');
+  });
+
+  it('combines absolute and relative without duplicating when both forms appear', () => {
+    const md = `
+[Absolute](https://audiocontrol.org/blog/foo/)
+[Relative](/blog/bar/)
+`;
+    const urls = extractAudioControlLinksFromMarkdown(md);
+    expect(urls).toContain('https://audiocontrol.org/blog/foo/');
+    expect(urls).toContain('https://audiocontrol.org/blog/bar/');
+  });
+});
+
+describe('canonicalizeUrl', () => {
+  it.each([
+    ['https://audiocontrol.org/blog/foo/', 'https://audiocontrol.org/blog/foo'],
+    ['https://AudioControl.org/blog/foo/', 'https://audiocontrol.org/blog/foo'],
+    ['https://audiocontrol.org/blog/foo', 'https://audiocontrol.org/blog/foo'],
+    ['https://audiocontrol.org/', 'https://audiocontrol.org/'],
+    ['https://audiocontrol.org', 'https://audiocontrol.org/'],
+  ])('normalizes %s → %s', (input, expected) => {
+    expect(canonicalizeUrl(input)).toBe(expected);
+  });
+
+  it('preserves query strings', () => {
+    expect(canonicalizeUrl('https://audiocontrol.org/x?y=1')).toBe(
+      'https://audiocontrol.org/x?y=1',
+    );
+  });
+});
+
+describe('auditCrossLinks with tool entries', () => {
+  function toolEntry(slug: string, contentUrl: string): CalendarEntry {
+    return {
+      slug,
+      title: slug,
+      description: '',
+      stage: 'Published',
+      contentType: 'tool',
+      contentUrl,
+      targetKeywords: [],
+      source: 'manual',
+      datePublished: '2025-01-01',
+    };
+  }
+
+  function blogEntry(slug: string): CalendarEntry {
+    return {
+      slug,
+      title: slug,
+      description: '',
+      stage: 'Published',
+      targetKeywords: [],
+      source: 'manual',
+      datePublished: '2025-01-01',
+    };
+  }
+
+  const TOOL_URL = 'https://audiocontrol.org/roland/s330/editor';
+
+  it('fetches the tool page and records outbound links', async () => {
+    const cal: EditorialCalendar = {
+      entries: [toolEntry('s330-editor', TOOL_URL), blogEntry('s330-post')],
+      distributions: [],
+    };
+    const report = await auditCrossLinks({
+      calendar: cal,
+      fetchBlogMarkdown: () => null,
+      fetchVideoDescription: async () => '',
+      fetchToolPage: async () => `
+        <a href="https://audiocontrol.org/blog/s330-post/">Read more</a>
+      `,
+    });
+    const toolAudit = report.entries.find((a) => a.entry.slug === 's330-editor');
+    expect(toolAudit?.outbound).toHaveLength(1);
+    expect(toolAudit?.outbound[0].resolvedSlug).toBe('s330-post');
+  });
+
+  it('flags missing backlink when tool links to blog but blog does not link back', async () => {
+    const cal: EditorialCalendar = {
+      entries: [toolEntry('s330-editor', TOOL_URL), blogEntry('s330-post')],
+      distributions: [],
+    };
+    const report = await auditCrossLinks({
+      calendar: cal,
+      fetchBlogMarkdown: () => 'A post with no links.',
+      fetchVideoDescription: async () => '',
+      fetchToolPage: async () => `
+        <a href="https://audiocontrol.org/blog/s330-post/">Read more</a>
+      `,
+    });
+    const blogAudit = report.entries.find((a) => a.entry.slug === 's330-post');
+    expect(blogAudit?.missingBacklinksTo).toContain('s330-editor');
+  });
+
+  it('resolves via unified byContentUrl index — blog MD to tool', async () => {
+    const cal: EditorialCalendar = {
+      entries: [toolEntry('s330-editor', TOOL_URL), blogEntry('s330-post')],
+      distributions: [],
+    };
+    const report = await auditCrossLinks({
+      calendar: cal,
+      fetchBlogMarkdown: () =>
+        'Try the [editor](/roland/s330/editor) to hear it.',
+      fetchVideoDescription: async () => '',
+      fetchToolPage: async () => '<p>No links.</p>',
+    });
+    const blogAudit = report.entries.find((a) => a.entry.slug === 's330-post');
+    expect(blogAudit?.outbound).toHaveLength(1);
+    expect(blogAudit?.outbound[0].resolvedSlug).toBe('s330-editor');
+  });
+
+  it('records fetch failures per-entry without aborting the audit', async () => {
+    const cal: EditorialCalendar = {
+      entries: [toolEntry('s330-editor', TOOL_URL), blogEntry('s330-post')],
+      distributions: [],
+    };
+    const report = await auditCrossLinks({
+      calendar: cal,
+      fetchBlogMarkdown: () => 'no links',
+      fetchVideoDescription: async () => '',
+      fetchToolPage: async () => {
+        throw new Error('404 Not Found');
+      },
+    });
+    const toolAudit = report.entries.find((a) => a.entry.slug === 's330-editor');
+    expect(toolAudit?.errors.join(' ')).toMatch(/404 Not Found/);
+    // The audit still returned — not aborted
+    expect(report.entries).toHaveLength(2);
+  });
+
+  it('records tools with missing contentUrl as errors', async () => {
+    const cal: EditorialCalendar = {
+      entries: [
+        {
+          slug: 'tool-without-url',
+          title: 't',
+          description: '',
+          stage: 'Published',
+          contentType: 'tool',
+          targetKeywords: [],
+          source: 'manual',
+          datePublished: '2025-01-01',
+        },
+      ],
+      distributions: [],
+    };
+    const report = await auditCrossLinks({
+      calendar: cal,
+      fetchBlogMarkdown: () => null,
+      fetchVideoDescription: async () => '',
+      fetchToolPage: async () => null,
+    });
+    expect(report.entries[0].errors.join(' ')).toMatch(/no contentUrl/);
+  });
+
+  it('excludes self-links from outbound', async () => {
+    const cal: EditorialCalendar = {
+      entries: [toolEntry('s330-editor', TOOL_URL)],
+      distributions: [],
+    };
+    const report = await auditCrossLinks({
+      calendar: cal,
+      fetchBlogMarkdown: () => null,
+      fetchVideoDescription: async () => '',
+      fetchToolPage: async () => `
+        <a href="/roland/s330/editor">Home</a>
+        <a href="https://example.com/other">Other</a>
+      `,
+    });
+    const toolAudit = report.entries.find((a) => a.entry.slug === 's330-editor');
+    // Self-link is filtered; only the external link remains
+    expect(toolAudit?.outbound.map((l) => l.url)).toEqual([
+      'https://example.com/other',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Phase 7 closes the cross-link audit loop for tool entries — the audit now fetches tool pages, extracts outbound links with cheerio, and resolves them against a unified `byContentUrl` index so gaps like "blog post X links to the editor but the editor page doesn't link back" are detected automatically
- Swapped regex-based HTML parsing for **cheerio** (30k stars, built on htmlparser2) after the initial hand-rolled version was correctly called out as fragile
- Live run against the real calendar found 4 real missing-backlink gaps — every blog post that links to `s330-web-editor` — because the editor page doesn't link back to any blog post yet. This is the exact gap Phase 7 was built to catch

## Changes

**HTML fetching**
- `scripts/lib/http/fetch-page.ts` — `fetchHtml(url)` with descriptive User-Agent, 10s AbortController timeout, distinct error prefixes per failure mode. Public pages only, no auth

**Link extraction (cheerio)**
- `extractLinksFromHtml(html, baseUrl?)` in `crosslinks.ts` — uses cheerio for robust DOM traversal. Extracts `href`/`src` attributes plus bare URLs from text; strips `<script>` and `<style>` first so inline JS strings don't leak in
- Skips anchor-only, `mailto:`/`tel:`/`javascript:`/`data:` schemes, feeds, sitemap, robots.txt
- Resolves relative URLs against the base

**Unified URL resolution**
- Single `byContentUrl` index across all three content types. Blog entries derive canonical URL from slug; youtube/tool use `contentUrl`
- `canonicalizeUrl` normalizes case + trailing slash, preserves query string
- `resolveUrl` tries YouTube video-ID match first (handles all four YouTube URL shapes as one target), falls back to canonical-URL lookup
- `extractBlogLinksFromDescription` → `extractAudioControlLinksFromText` (now matches any audiocontrol.org URL, not just `/blog/`)
- New `extractAudioControlLinksFromMarkdown` catches markdown-relative links like `[editor](/roland/s330/editor)`

**Audit**
- Tool branch: fetch page, extract links, resolve via unified index. Self-links filtered at record time
- Phase 6 tool-skips removed in both passes — tools now participate fully in bidirectional reciprocation detection
- Per-entry fetch failures recorded as errors; audit never aborts on a single bad fetch

**Skill**
- `/editorial-cross-link-review` updated to describe tool-page fetching, unified resolution, cheerio usage

**Dependency**
- Adds `cheerio@^1.2.0` as a devDependency

## Commits

- `a6d96e9` — feat: Phase 7 — tool cross-link audit with cheerio HTML parsing
- `18764f6` — docs: tidy workplan and document canonicalizeUrl best-effort behavior

## Test plan

- [x] `npm test` — 85/85 unit tests pass (63 Phase 4/5/6 + 22 Phase 7 covering cheerio edge cases, markdown-relative extraction, canonicalizeUrl normalization, tool-entry outbound resolution, blog-to-tool via relative link, missing-backlink reciprocation in both directions, fetch-failure-per-entry, missing-contentUrl errors, self-link exclusion)
- [x] `npm run build` — clean
- [x] Type check (`tsc --noEmit`) — no errors in editorial/reddit/youtube/http modules; no new `any`/`as Type` introduced
- [x] Live audit run against the real calendar + live YouTube API + live fetch of the S-330 editor page — 10 entries audited, 4 real backlink gaps surfaced, 0 errors, idempotent
- [x] Code review performed; only advisory findings, all addressed (canonicalizeUrl behavior documented, duplicate workplan checkboxes ticked)

## Known follow-ups

- No Phase 8 scoped yet. Natural next directions if useful: (a) fix the actual 4 backlink gaps surfaced by the live audit by updating the S-330 editor page to link back to relevant blog posts; (b) add a batch-action skill to apply suggested cross-links after review

Closes oletizi/audiocontrol.org#59
