### PR TITLE
docs: session-end for Phases 5-7 + seed 6 blog post ideas

### DIFF
--- a/DEVELOPMENT-NOTES.md
+++ b/DEVELOPMENT-NOTES.md
@@ -4,6 +4,47 @@ Session journal for audiocontrol.org. Each entry records what was tried, what wo
 
 ---
 
+## 2026-04-17: Editorial Calendar — Phases 5, 6, 7 (Subreddit Tracking + YouTube + Tool Cross-link Audit)
+### Feature: editorial-calendar
+### Worktree: audiocontrol.org-editorial-calendar
+
+**Goal:** Continue extending the editorial calendar with Phase 5 (subreddit tracking + Reddit sync), then Phase 6 (YouTube videos + tools as first-class calendar entries + cross-link audit), then Phase 7 (tool-page HTML audit). Close the loop so every piece of content across blog / YouTube / tool is tracked and cross-referenced automatically.
+
+**Accomplished:**
+- **Phase 5 shipped** (PR #58 merged as `8f0a469`): Platform/channel sub-tracking, curated `editorial-channels.json` map, `/editorial-reddit-sync` and `/editorial-reddit-opportunities` skills. First live sync found 2 attributed shares of the claude-vs-codex-codex-perspective post
+- **Reddit auth simplified to unauthenticated**: switched from OAuth password-grant to Reddit's public `.json` endpoints after user flagged that auth setup friction eats too much of the tool's value. Single-line config (`{"username": "..."}`) vs. the five-field OAuth setup
+- **Phase 6 shipped** (PR #60 merged as `f6cba95`): YouTube videos as first-class CalendarEntry with full Ideas → Published lifecycle; YouTube Data API v3 integration via single API key (matched existing `youtube-key.txt` convention); `/editorial-cross-link-review` skill; Reddit sync extended to match YouTube URLs. Scope creep mid-phase added `tool` as a third content type (standalone apps on audiocontrol.org) so the S-330 editor could be tracked too
+- **Calendar reconciled**: added s330-drum-crunch-video (YouTube) and s330-web-editor (tool) as Published entries; all 8 of /u/Middle-Feeling1313's Reddit submissions now attributed to the right calendar entry (2 to blog, 4 to video, 2 to tool)
+- **Phase 7 shipped** (PR #61 merged as `9bed3d4`): tool cross-link audit via cheerio HTML parsing, unified `byContentUrl` index across all three content types, `extractAudioControlLinksFromMarkdown` catches markdown-relative links, `fetchHtml` with AbortController timeout. Live audit against the real calendar found 4 real backlink gaps — every blog post that links to the editor — because the editor page doesn't link back to any blog post yet
+- 85 unit tests total at session end; all pass; build + typecheck clean through all three phases
+
+**Didn't Work:**
+- **Hand-rolled regex HTML parsing** for Phase 7 was the wrong starting point — real HTML is too quirky (unclosed tags, inline JS strings that look like hrefs, CDATA). User flagged it mid-implementation; switched to cheerio
+- **First auth attempt was OAuth password-grant** — full Reddit app registration with client ID/secret/password in plaintext, plus 2FA-off requirement. User's response ("30% of tool-use time fighting auth") made clear this was overkill for read-only access to public data
+
+**Course Corrections:**
+- [PROCESS] User asked if I'd read the Reddit Developer Platform docs (Devvit) before I recommended the classic Reddit API. I had not — I'd defaulted to the classic API from training-data knowledge. Fetched the docs, confirmed the classic path was still right for our use case (Devvit is for apps hosted *inside* Reddit), but should have checked the current authoritative source before recommending. Lesson: when recommending a specific API surface, verify against the provider's current docs
+- [PROCESS] Before committing the Reddit integration, I'd skipped exploring simpler auth approaches. User surfaced the question "is there a non-OAuth way?" which there was (public `.json` endpoints), and that's what we shipped. Lesson: for read-only access to public data, always consider whether auth is needed at all before designing an auth flow
+- [COMPLEXITY] First attempt at Phase 7 HTML parsing was hand-rolled regex. User correctly called this out as fragile. Switched to a real HTML parser
+- [PROCESS] After agreeing to use an HTML parser, I jumped to installing `node-html-parser` without researching alternatives. User said "make sure the one you pick is widely used and has social capital." Researched the landscape (cheerio 30k stars with GitHub/Airbnb/HasData sponsorship vs node-html-parser 1.2k stars) and picked cheerio, which is the obvious answer by that criterion. Lesson: dependency choices need research even when the first candidate "looks fine"
+
+**Quantitative:**
+- Messages: ~150 across the continuation (three ship cycles)
+- Commits on the feature branch: ~18 across Phases 5, 6, 7
+- PRs shipped and merged: 3 (#58, #60, #61)
+- Unit tests: 85/85 passing at end; grew from 10 (Phase 4) to 85 (Phase 7)
+- GitHub issues closed: #56, #57, #59 (all three via PR merges)
+- Corrections: 4 — the three [PROCESS] ones above plus the [COMPLEXITY] one on regex-vs-cheerio
+
+**Insights:**
+- **Cheap iteration beats heavy planning for infrastructure code.** The "ship Phase N + scope Phase N+1 docs" pattern repeated three times — each phase shipped its main value while the next phase captured the next observed gap. Phase 5's live sync surfaced Phase 6's motivation (YouTube shares had nowhere to land). Phase 6's live use surfaced Phase 7's motivation (blog posts linked to the editor with no backlink visibility). Planning N+1 from real N-1 data is dramatically better than planning ahead
+- **Auth friction compounds across multiple integrations.** We now have Reddit (0 credentials), YouTube (1 API key), Umami (1 API key), GA4 (service account), GitHub (gh CLI). Keeping each integration dead-simple meant the editorial workflow can touch all of them without the user fighting auth. The Reddit OAuth-to-public pivot was the right call even though I'd already built the OAuth version
+- **User-injected scope creep is often correct.** The `tool` content type wasn't in the Phase 6 plan; it got added mid-phase after the live Reddit sync found 2 editor-promo shares with no home. Adding it was the right call — the type system already had the branching structure, so the marginal cost was small, and it unlocked a whole category of future tracking (any audiocontrol.org page that's not a blog post could be a tool entry)
+- **I/O at the edges pays off for audit code.** `auditCrossLinks` takes three closures (fetchBlogMarkdown, fetchVideoDescription, fetchToolPage). Tests use fixture closures; the skill wires in real implementations. When Phase 7 added a third closure, existing tests kept working with trivial `async () => null` stubs — no production-code change required to keep test coverage intact
+- **Social capital isn't vanity — it's risk reduction.** 30k stars on cheerio means "audited by 30k people who use it in production." 1.2k on node-html-parser means "someone wrote it and it mostly works." For a long-lived dep that I won't maintain, the former is the choice every time
+
+---
+
 ## 2026-04-17: Editorial Calendar — Phase 4 Social Distribution + GA4 Migration
 ### Feature: editorial-calendar
 ### Worktree: audiocontrol.org-editorial-calendar

--- a/docs/1.0/001-IN-PROGRESS/editorial-calendar/README.md
+++ b/docs/1.0/001-IN-PROGRESS/editorial-calendar/README.md
@@ -1,9 +1,9 @@
 # Editorial Calendar
 
-**Status:** In Progress (Phase 5 scoping)
+**Status:** All Phases Complete (ready for `/feature-complete`)
 **Feature Branch:** `feature/editorial-calendar`
 **GitHub Issue:** oletizi/audiocontrol.org#29 (parent)
-**Shipped PRs:** oletizi/audiocontrol.org#46 (Phases 1-3), oletizi/audiocontrol.org#55 (Phase 4)
+**Shipped PRs:** #46 (Phases 1-3), #55 (Phase 4), #58 (Phase 5), #60 (Phase 6), #61 (Phase 7)
 
 ## Overview
 
@@ -17,9 +17,9 @@ Structured editorial calendar that tracks content through its lifecycle (idea th
 | 2 | Post Scaffolding | Complete |
 | 3 | Analytics Integration | Complete |
 | 4 | Social Distribution Tracking | Complete |
-| 5 | Subreddit Tracking & Cross-posting Opportunities | Ready to ship |
-| 6 | YouTube as First-Class Content + Cross-link Audit | In Progress |
-| 7 | Tool Cross-link Audit | In Progress |
+| 5 | Subreddit Tracking & Cross-posting Opportunities | Complete |
+| 6 | YouTube as First-Class Content + Cross-link Audit | Complete |
+| 7 | Tool Cross-link Audit | Complete |
 
 ## Dependencies
 

--- a/docs/editorial-calendar.md
+++ b/docs/editorial-calendar.md
@@ -2,7 +2,14 @@
 
 ## Ideas
 
-*No entries.*
+| Slug | Title | Description | Keywords | Source |
+|------|------|------|------|------|
+| building-the-editorial-calendar-feature | Building the Editorial Calendar Feature | A writeup of the editorial-calendar feature itself — why ad-hoc content creation needed a system, how the Ideas→Published lifecycle works, and how analytics, Reddit, and YouTube got wired into one virtuous loop. |  | manual |
+| analytics-automation-feature | Analytics Automation Feature | How the automated-analytics feature turns Umami / GA4 / Search Console into actionable recommendations — the scorecard, striking-distance queries, CTR opportunities, and the feedback loop into the editorial calendar. |  | manual |
+| feature-image-automation-feature | Feature Image Automation Feature | How we went from hand-cropping images to a two-way workflow pipeline between Claude Code skills and a local preview gallery for AI-generated feature images — the JSONL workflow queue, the state machine, and why dev-only Astro routes beat a dashboard app. |  | manual |
+| codex-parallel-implementation-and-work-checking-on-mesa-ii | Codex Parallel Implementation and Work Checking on MESA II | Running Claude Code and Codex against the same MESA II reverse-engineering problem in parallel, using each to cross-check the other. How disagreement between agents surfaces real bugs; how agreement gives higher confidence than a single agent alone. |  | manual |
+| video-demo-feature | Video Demo Feature | Making YouTube videos a first-class content type alongside blog posts — same lifecycle, same cross-link audit, same distribution tracking. How treating videos as editorial entries (not marketing afterthoughts) changes the content workflow. |  | manual |
+| lightweight-web-workflow-dashboards-with-action-queues-for-claude-code | Lightweight Web Workflow Dashboards with Action Queues for Claude Code | A pattern: instead of rigid hand-coded review UIs, build lightweight web dashboards that present an action queue Claude Code pushes work into and the user resolves. Queue is a JSON file in git (no database). Claude Code is the backend (no rigid system). The workflow is a family of Claude skills (see audiocontrol.org /feature-image-* family). Pass messages back and forth via the queue — the dashboard surfaces complex questions Claude has, user responses save back. Works for feature images, could work for any high-bandwidth review loop. |  | manual |
 
 ## Planned
 


### PR DESCRIPTION
## Summary

Two bookkeeping commits for the editorial-calendar feature branch — no implementation code.

- `003272f` — session-end docs for Phases 5, 6, 7 (journal entry + feature README now marks all 7 phases Complete)
- `7952982` — seeds 6 blog post ideas into the `Ideas` stage of `docs/editorial-calendar.md` as a content backlog to plan against

The feature branch is staying open as the long-running home for editorial-calendar work. This PR keeps main's docs current without running `/feature-complete`.

## Content ideas seeded

| Slug | Angle |
|---|---|
| `building-the-editorial-calendar-feature` | Meta-writeup of this feature |
| `analytics-automation-feature` | Automated-analytics feature deep-dive |
| `feature-image-automation-feature` | Feature-image workflow pipeline post |
| `codex-parallel-implementation-and-work-checking-on-mesa-ii` | Two-agent cross-check pattern |
| `video-demo-feature` | Making videos first-class editorial content |
| `lightweight-web-workflow-dashboards-with-action-queues-for-claude-code` | The JSONL-queue + Claude-Code-as-backend pattern |

Each has a placeholder description; keywords/topics will be set at `/editorial-plan` time.

## Test plan

- [x] Calendar still round-trips cleanly (the existing parser tests exercise Ideas stage with and without columns)
- [x] No code changes — docs and markdown only; build and unit tests already green from prior PRs on this branch

No issue closed by this PR — feature branch remains open per the user's ongoing-use plan.
