### PR TITLE
fix(netlify): remove [build] block so each site's UI settings apply

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,12 +1,14 @@
-[build]
-  command = "npm run build:audiocontrol"
-  publish = "dist/audiocontrol"
-
-# Per-site redirects live in each site's public directory so they only
-# apply to that site's build output:
-#   src/sites/audiocontrol/public/_redirects     — Roland editor proxies
-#   src/sites/editorialcontrol/public/_redirects — none yet
+# This repo is a multi-site Astro tree (audiocontrol.org + editorialcontrol.org).
+# A repo-level netlify.toml applies to every Netlify site deployed from the
+# repository, and its values beat per-site UI settings. To avoid one site's
+# build command or redirects leaking into the other, this file is kept empty.
 #
-# Netlify's own netlify.toml applies to ALL deploys from this repo, so
-# any [[redirects]] added here would leak across both Netlify sites.
-# Keep this file limited to audiocontrol's default build settings.
+# Each Netlify site's build command and publish dir are configured in the
+# Netlify UI:
+#   audiocontrol.org     → command: npm run build:audiocontrol     publish: dist/audiocontrol
+#   editorialcontrol.org → command: npm run build:editorialcontrol publish: dist/editorialcontrol
+#
+# Per-site redirects live in each site's own public directory so they only
+# apply to that site's build output:
+#   src/sites/audiocontrol/public/_redirects     — Roland editor proxies, sitemap alias
+#   src/sites/editorialcontrol/public/_redirects — sitemap alias


### PR DESCRIPTION
## Summary

The repo-level `netlify.toml` `[build]` block was pinned to audiocontrol's command (`npm run build:audiocontrol`) and publish dir (`dist/audiocontrol`). Because netlify.toml beats UI settings on every Netlify site deployed from this repo, the newly-created editorialcontrol.org Netlify site was running audiocontrol's build and publishing audiocontrol's dist under editorialcontrol.org.

Fix: strip the `[build]` block. Each Netlify site now configures its own build command and publish dir in the Netlify UI. Both UIs have been populated before this change lands:

- audiocontrol.org → `npm run build:audiocontrol` / `dist/audiocontrol`
- editorialcontrol.org → `npm run build:editorialcontrol` / `dist/editorialcontrol`

Redirects are already per-site via each site's `public/_redirects` (landed in e0e0d6b). netlify.toml is left with only a header comment explaining the setup.

## Test plan

- [x] Both Netlify deploy previews on this PR build cleanly under each site's correct UI command
- [ ] Post-merge: audiocontrol.org deploys from `main` still serves from `dist/audiocontrol` (spot-check homepage + a blog post)
- [ ] Post-merge: editorialcontrol.org (when DNS resolves) serves from `dist/editorialcontrol` (spot-check homepage + `/blog/`)
