### PR TITLE
editorial-review: in-situ margin-note composer (no modal)

### DIFF
--- a/journal/editorial/history/2026-04-22T18-39-30-766Z-d6e381ef-80c9-4418-b50e-2505f234d7eb.json
+++ b/journal/editorial/history/2026-04-22T18-39-30-766Z-d6e381ef-80c9-4418-b50e-2505f234d7eb.json
@@ -1,0 +1,22 @@
+{
+  "id": "d6e381ef-80c9-4418-b50e-2505f234d7eb",
+  "timestamp": "2026-04-22T18:39:30.766Z",
+  "entry": {
+    "kind": "annotation",
+    "at": "2026-04-22T18:39:30.766Z",
+    "annotation": {
+      "type": "comment",
+      "workflowId": "027c96d3-149e-4c13-8419-b149f1d9d6ec",
+      "version": 1,
+      "range": {
+        "start": 8055,
+        "end": 8081
+      },
+      "text": "What does \"AI-assisted output quality\" mean?",
+      "category": "other",
+      "anchor": "AI-assisted output quality",
+      "id": "d6e381ef-80c9-4418-b50e-2505f234d7eb",
+      "createdAt": "2026-04-22T18:39:30.766Z"
+    }
+  }
+}

--- a/journal/editorial/history/2026-04-22T18-40-10-124Z-d6499f2c-952b-4ed4-9a28-9a7d1afc6f87.json
+++ b/journal/editorial/history/2026-04-22T18-40-10-124Z-d6499f2c-952b-4ed4-9a28-9a7d1afc6f87.json
@@ -1,0 +1,22 @@
+{
+  "id": "d6499f2c-952b-4ed4-9a28-9a7d1afc6f87",
+  "timestamp": "2026-04-22T18:40:10.124Z",
+  "entry": {
+    "kind": "annotation",
+    "at": "2026-04-22T18:40:10.124Z",
+    "annotation": {
+      "type": "comment",
+      "workflowId": "027c96d3-149e-4c13-8419-b149f1d9d6ec",
+      "version": 1,
+      "range": {
+        "start": 8085,
+        "end": 8098
+      },
+      "text": "Table stakes for what?",
+      "category": "other",
+      "anchor": "table stakes.",
+      "id": "d6499f2c-952b-4ed4-9a28-9a7d1afc6f87",
+      "createdAt": "2026-04-22T18:40:10.124Z"
+    }
+  }
+}

--- a/journal/editorial/history/2026-04-22T18-42-55-992Z-63bd5545-6009-4400-9a27-ec813190ebd8.json
+++ b/journal/editorial/history/2026-04-22T18-42-55-992Z-63bd5545-6009-4400-9a27-ec813190ebd8.json
@@ -1,0 +1,22 @@
+{
+  "id": "63bd5545-6009-4400-9a27-ec813190ebd8",
+  "timestamp": "2026-04-22T18:42:55.992Z",
+  "entry": {
+    "kind": "annotation",
+    "at": "2026-04-22T18:42:55.992Z",
+    "annotation": {
+      "type": "comment",
+      "workflowId": "027c96d3-149e-4c13-8419-b149f1d9d6ec",
+      "version": 1,
+      "range": {
+        "start": 8099,
+        "end": 8168
+      },
+      "text": "This instinct isn't *wrong*, per se. It's just that, with the insane power of a coding agent at your disposal, you're leaving so much on the table by stopping there.",
+      "category": "other",
+      "anchor": "The instinct that produces — write a better prompt — is the wrong one",
+      "id": "63bd5545-6009-4400-9a27-ec813190ebd8",
+      "createdAt": "2026-04-22T18:42:55.992Z"
+    }
+  }
+}

--- a/src/shared/editorial-review-client.ts
+++ b/src/shared/editorial-review-client.ts
@@ -98,8 +98,8 @@ export function initEditorialReview(): void {
   const editToolbar = q<HTMLElement>('[data-edit-toolbar]');
   const editHint = q<HTMLElement>('[data-edit-hint]');
   const addBtn = q<HTMLButtonElement>('[data-add-comment-btn]');
-  const modal = q<HTMLElement>('[data-comment-modal]');
-  const modalQuote = q<HTMLElement>('[data-modal-quote]');
+  const composer = q<HTMLElement>('[data-comment-composer]');
+  const composerQuote = q<HTMLElement>('[data-composer-quote]');
   const categorySel = q<HTMLSelectElement>('[data-comment-category]');
   const textArea = q<HTMLTextAreaElement>('[data-comment-text]');
   const sidebarList = q<HTMLElement>('[data-sidebar-list]');
@@ -325,28 +325,43 @@ export function initEditorialReview(): void {
     pendingRange = offsets;
   });
 
-  function openMarkModal(): void {
+  /**
+   * Reveal the in-margin composer at the top of the margin-rail
+   * with the selected quote pre-populated. No modal — the composer
+   * lives inside the same sidebar that hosts saved marks, so the
+   * reading frame never gets pulled out from under the operator.
+   */
+  function openComposer(): void {
     if (!pendingRange) return;
-    modalQuote.textContent = extractQuote(pendingRange);
+    composerQuote.textContent = extractQuote(pendingRange);
     textArea.value = '';
     categorySel.value = 'other';
-    modal.hidden = false;
+    composer.hidden = false;
+    composer.classList.add('er-marginalia-composer--entering');
+    // Next frame, strip the entering class so the CSS transition
+    // runs. Reading the offsetWidth forces a layout flush which is
+    // enough to separate the two class changes into distinct frames.
+    void composer.offsetWidth;
+    composer.classList.remove('er-marginalia-composer--entering');
     addBtn.hidden = true;
     textArea.focus();
   }
 
-  addBtn.addEventListener('click', openMarkModal);
+  addBtn.addEventListener('click', openComposer);
 
   // Operator-friendly second entry: click anywhere in the margin-notes
   // sidebar (but not on an existing note, which has its own scroll-to
-  // behavior) to open the Mark modal for the current selection. This
-  // honors the natural "I selected text → now I click the margin"
-  // instinct that the floating pencil alone doesn't satisfy.
+  // behavior, and not on the composer itself) to open the composer
+  // for the current selection. This honors the natural "I selected
+  // text → now I click the margin" instinct that the floating pencil
+  // alone doesn't satisfy.
   const sidebar = q<HTMLElement>('[data-comments-sidebar]');
   sidebar.addEventListener('mousedown', (ev) => {
     const target = ev.target instanceof HTMLElement ? ev.target : null;
     // Clicks on an existing note: let that handler run (scroll to highlight).
     if (target?.closest('.er-marginalia-item')) return;
+    // Clicks inside the composer: let normal form input behavior run.
+    if (target?.closest('[data-comment-composer]')) return;
     // Preserve the selection the browser is about to clear on mouseup.
     // selectionchange already stashed `pendingRange`; just suppress the
     // default mousedown so the selection survives into click.
@@ -355,23 +370,34 @@ export function initEditorialReview(): void {
   sidebar.addEventListener('click', (ev) => {
     const target = ev.target instanceof HTMLElement ? ev.target : null;
     if (target?.closest('.er-marginalia-item')) return;
+    if (target?.closest('[data-comment-composer]')) return;
     if (!pendingRange) {
       showToast('Select text in the draft first, then click here to mark it.');
       return;
     }
-    openMarkModal();
+    openComposer();
   });
 
-  // ---- Modal submission ----
+  // ---- Composer submission ----
 
-  q('[data-modal-backdrop]').addEventListener('click', closeModal);
-  q('[data-action="cancel-comment"]').addEventListener('click', closeModal);
+  q('[data-action="cancel-comment"]').addEventListener('click', closeComposer);
   q('[data-action="submit-comment"]').addEventListener('click', submitComment);
+  // Cmd/Ctrl+Enter submits from anywhere inside the composer.
+  composer.addEventListener('keydown', (ev) => {
+    const e = ev as KeyboardEvent;
+    if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+      e.preventDefault();
+      void submitComment();
+    }
+  });
 
-  function closeModal(): void { modal.hidden = true; pendingRange = null; }
+  function closeComposer(): void {
+    composer.hidden = true;
+    pendingRange = null;
+  }
 
   async function submitComment(): Promise<void> {
-    if (!pendingRange) { closeModal(); return; }
+    if (!pendingRange) { closeComposer(); return; }
     const text = textArea.value.trim();
     if (!text) { showToast('Comment text is required', true); return; }
     // Capture the selected text at comment time so later versions
@@ -398,7 +424,7 @@ export function initEditorialReview(): void {
       if (!res.ok) { showToast(`Annotate failed: ${body.error || res.status}`, true); return; }
       wrapRange(body.annotation.range, body.annotation.id);
       addSidebarItem(body.annotation, 'current');
-      closeModal();
+      closeComposer();
       showToast('Comment saved');
     } catch (e) {
       showToast(`Network error: ${(e as Error).message}`, true);
@@ -907,8 +933,9 @@ export function initEditorialReview(): void {
     if (typing) {
       if (ev.key === 'Escape') {
         target.blur();
-        // If the operator was typing inside the comment modal, also close it.
-        if (!modal.hidden) closeModal();
+        // If the operator was typing inside the margin-note composer,
+        // also dismiss it. Same gesture, same expectation.
+        if (!composer.hidden) closeComposer();
       }
       return;
     }
@@ -922,7 +949,7 @@ export function initEditorialReview(): void {
     }
     if (ev.key === 'Escape') {
       if (shortcutsOverlay && !shortcutsOverlay.hidden) { showShortcuts(false); return; }
-      if (!modal.hidden) { closeModal(); return; }
+      if (!composer.hidden) { closeComposer(); return; }
     }
     if (ev.key === 'e') { ev.preventDefault(); toggleBtn.click(); return; }
     if (ev.key === 'a') { ev.preventDefault(); approveBtn?.click(); return; }

--- a/src/shared/editorial-review.css
+++ b/src/shared/editorial-review.css
@@ -1186,93 +1186,132 @@ body:has([data-review-ui="longform"]) .site-footer {
   margin-left: var(--er-space-1);
 }
 
-/* ---------- Comment modal ---------- */
+/* ---------- Margin-note composer ----------
+ *
+ * In-situ replacement for the old comment modal. Lives inside the
+ * margin rail (same `[data-comments-sidebar]` aside that hosts
+ * saved notes) so starting a new mark never pulls focus off the
+ * draft. Saving promotes the composer contents into a normal
+ * margin item rendered below; cancel dismisses without leaving
+ * a trace. Scoped under [data-review-ui="longform"] so the
+ * cream-on-dark host theme can't leak its link colors onto our
+ * controls. */
 
-.er-modal {
-  position: fixed;
-  inset: 0;
-  z-index: 100;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: var(--er-space-3);
-}
-
-.er-modal-backdrop {
-  position: absolute;
-  inset: 0;
-  background: rgba(26,22,20,0.3);
-  backdrop-filter: blur(4px);
-}
-
-.er-modal-panel {
+[data-review-ui="longform"] .er-marginalia-composer {
   position: relative;
-  background: var(--er-paper);
-  border: var(--er-rule-med);
-  max-width: 32rem;
-  width: 100%;
-  padding: var(--er-space-4);
-  box-shadow: 4px 4px 0 rgba(26,22,20,0.15);
+  padding: var(--er-space-2) var(--er-space-2) var(--er-space-2) var(--er-space-3);
+  margin: 0 0 var(--er-space-2);
+  /* Red-pencil left rail distinguishes a draft slip from saved
+   * notes (which use the softer --er-red-soft). Same rhythm; a
+   * single degree warmer. */
+  border-left: 3px solid var(--er-red-pencil);
+  border-bottom: 1px solid var(--er-red-pencil);
+  background: linear-gradient(180deg, var(--er-paper-2) 0%, var(--er-paper) 100%);
+  transition: opacity 220ms ease-out, transform 220ms ease-out;
 }
 
-.er-modal-header {
+/* Entry frame: composer is translated up + faded when first
+ * revealed; a single frame later the class is removed and the
+ * transition slides it home. Gives the operator a clear "arrived
+ * on the rail" moment without being precious about it. */
+[data-review-ui="longform"] .er-marginalia-composer--entering {
+  opacity: 0;
+  transform: translateY(-6px);
+}
+
+[data-review-ui="longform"] .er-marginalia-composer-head {
   font-family: var(--er-font-mono);
-  font-size: 0.7rem;
+  font-size: 0.62rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--er-red-pencil);
-  border-bottom: 1px solid var(--er-red-pencil);
-  padding-bottom: var(--er-space-1);
-  margin: 0 0 var(--er-space-3);
+  margin: 0 0 var(--er-space-1);
 }
 
-.er-modal-quote {
+[data-review-ui="longform"] .er-marginalia-composer-quote {
+  /* Match saved-item quote styling exactly so the composer reads
+   * as a draft in the same rhythm as the marks below it. Known
+   * legible on cream. */
   font-family: var(--er-font-display);
   font-style: italic;
-  font-size: 1rem;
-  border-left: 3px solid var(--er-red-soft);
-  padding: var(--er-space-1) var(--er-space-2);
-  color: var(--er-ink-soft);
-  background: var(--er-paper-2);
-  margin: 0 0 var(--er-space-3);
+  font-size: 0.88rem;
   line-height: 1.4;
+  color: var(--er-ink-soft);
+  border-left: 2px solid var(--er-red-soft);
+  padding: 0 var(--er-space-1);
+  margin: 0 0 var(--er-space-2);
+  /* Belt-and-suspenders against any host-theme color bleed: be
+   * explicit that the text is the soft-ink, not whatever a parent
+   * `<blockquote>` rule might have set. */
+  background: transparent;
 }
 
-.er-modal-label {
+[data-review-ui="longform"] .er-marginalia-composer-label {
   font-family: var(--er-font-mono);
-  font-size: 0.7rem;
-  letter-spacing: 0.1em;
+  font-size: 0.62rem;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--er-faded);
   display: block;
-  margin-bottom: var(--er-space-0);
+  margin: var(--er-space-1) 0 0.15rem;
 }
 
-.er-modal-panel select,
-.er-modal-panel textarea {
+[data-review-ui="longform"] .er-marginalia-composer-select,
+[data-review-ui="longform"] .er-marginalia-composer-textarea {
   width: 100%;
   font: inherit;
-  padding: var(--er-space-1) var(--er-space-2);
-  border: var(--er-rule-thin);
+  padding: 0.35rem var(--er-space-1);
   background: var(--er-paper);
   color: var(--er-ink);
-  margin-bottom: var(--er-space-2);
-  font-family: var(--er-font-body);
-  border-radius: 2px;
-}
-.er-modal-panel textarea {
-  font-family: var(--er-font-display);
-  font-variation-settings: "opsz" 18, "wght" 400;
-  min-height: 5rem;
-  resize: vertical;
-  line-height: 1.5;
+  border: 1px solid var(--er-faded-2);
+  border-radius: 0;
+  margin-bottom: var(--er-space-1);
+  transition: border-color 120ms ease;
 }
 
-.er-modal-actions {
+[data-review-ui="longform"] .er-marginalia-composer-select:focus,
+[data-review-ui="longform"] .er-marginalia-composer-textarea:focus {
+  outline: none;
+  border-color: var(--er-red-pencil);
+}
+
+[data-review-ui="longform"] .er-marginalia-composer-textarea {
+  font-family: var(--er-font-body);
+  font-size: 0.92rem;
+  min-height: 4.5rem;
+  line-height: 1.5;
+  resize: vertical;
+  color: var(--er-ink);
+}
+[data-review-ui="longform"] .er-marginalia-composer-textarea::placeholder {
+  color: var(--er-faded);
+  font-style: italic;
+}
+
+[data-review-ui="longform"] .er-marginalia-composer-actions {
   display: flex;
   justify-content: flex-end;
   gap: var(--er-space-1);
-  margin-top: var(--er-space-2);
+  margin-top: var(--er-space-1);
+}
+
+[data-review-ui="longform"] .er-marginalia-composer-hint {
+  font-family: var(--er-font-mono);
+  font-size: 0.58rem;
+  letter-spacing: 0.1em;
+  color: var(--er-faded-2);
+  margin: 0.35rem 0 0;
+  text-align: right;
+}
+[data-review-ui="longform"] .er-marginalia-composer-hint kbd {
+  font-family: var(--er-font-mono);
+  font-size: 0.58rem;
+  padding: 0.1rem 0.3rem;
+  border: 1px solid var(--er-faded-2);
+  border-radius: 2px;
+  color: var(--er-faded);
+  margin: 0 0.1rem;
+  background: transparent;
 }
 
 /* ---------- Toast ---------- */

--- a/src/sites/editorialcontrol/pages/dev/editorial-review/[slug].astro
+++ b/src/sites/editorialcontrol/pages/dev/editorial-review/[slug].astro
@@ -186,18 +186,18 @@ function stateLabel(state?: string): string {
     <aside class="er-marginalia" data-comments-sidebar aria-label="Margin notes">
       <p class="er-marginalia-head">Margin notes</p>
       <p class="er-marginalia-empty" data-sidebar-empty>Select text in the draft, then either click the floating <em>Mark</em> pencil above your selection — or click anywhere here in the margin to open the note.</p>
-      <ol class="er-marginalia-list" data-sidebar-list></ol>
-    </aside>
 
-    <button class="er-pencil-btn" data-add-comment-btn hidden type="button">Mark</button>
-
-    <div class="er-modal" data-comment-modal hidden role="dialog" aria-modal="true" aria-label="Add comment">
-      <div class="er-modal-backdrop" data-modal-backdrop></div>
-      <div class="er-modal-panel">
-        <p class="er-modal-header">New margin note</p>
-        <blockquote class="er-modal-quote" data-modal-quote></blockquote>
-        <label class="er-modal-label" for="comment-category">Mark as</label>
-        <select id="comment-category" data-comment-category>
+      <!--
+        In-margin composer. Lives inside the margin rail itself so
+        leaving a mark never pulls focus off the draft. Hidden until
+        the operator starts a new mark; populates with the selected
+        quote; submits in place and promotes into the list below.
+      -->
+      <section class="er-marginalia-composer" data-comment-composer hidden aria-label="New margin note">
+        <p class="er-marginalia-composer-head">New mark</p>
+        <div class="er-marginalia-composer-quote" data-composer-quote></div>
+        <label class="er-marginalia-composer-label" for="comment-category">Mark as</label>
+        <select id="comment-category" class="er-marginalia-composer-select" data-comment-category>
           <option value="other" selected>other</option>
           <option value="voice-drift">voice-drift</option>
           <option value="missing-receipt">missing-receipt</option>
@@ -206,14 +206,27 @@ function stateLabel(state?: string): string {
           <option value="fake-authority">fake-authority</option>
           <option value="structural">structural</option>
         </select>
-        <label class="er-modal-label" for="comment-text">Note</label>
-        <textarea id="comment-text" data-comment-text rows="4" placeholder="What needs attention here?"></textarea>
-        <div class="er-modal-actions">
-          <button type="button" class="er-btn" data-action="cancel-comment">Cancel</button>
-          <button type="button" class="er-btn er-btn-primary" data-action="submit-comment">Leave mark</button>
+        <label class="er-marginalia-composer-label" for="comment-text">Note</label>
+        <textarea
+          id="comment-text"
+          class="er-marginalia-composer-textarea"
+          data-comment-text
+          rows="4"
+          placeholder="What needs attention here?"
+        ></textarea>
+        <div class="er-marginalia-composer-actions">
+          <button type="button" class="er-btn er-btn-small" data-action="cancel-comment">Cancel</button>
+          <button type="button" class="er-btn er-btn-small er-btn-primary" data-action="submit-comment">Leave mark</button>
         </div>
-      </div>
-    </div>
+        <p class="er-marginalia-composer-hint">
+          <kbd>⌘</kbd><kbd>↵</kbd> save · <kbd>esc</kbd> cancel
+        </p>
+      </section>
+
+      <ol class="er-marginalia-list" data-sidebar-list></ol>
+    </aside>
+
+    <button class="er-pencil-btn" data-add-comment-btn hidden type="button">Mark</button>
 
     <div class="er-toast" data-toast hidden></div>
 


### PR DESCRIPTION
## Summary

Replace the modal-dialog margin-note UI with an inline composer that lives inside the margin rail itself. Matches the pattern every modern annotation UI uses (Medium, Hypothesis, Figma, GitHub PR line comments) and keeps the reading frame intact — no focus-stealing overlay.

## Why

The previous modal was a two-problem design:
1. The quoted context rendered in low-contrast italic against the cream panel, making the selection illegible.
2. It pulled focus off the draft, so a quick "mark this and keep reading" gesture became a modal transaction.

Both trace to treating margin notes as a form-submission event instead of an in-place authoring task.

## What changed

- Composer lives in `[data-comments-sidebar]`, revealed at the top of the rail above saved notes when Mark is clicked.
- Same visual rhythm as saved notes; distinguished by a red-pencil left rail + `NEW MARK` mono label (saved notes use red-soft).
- Quote uses `<div>` not `<blockquote>` to dodge BlogLayout's `.essay-body :global(blockquote)` chartreuse rule whose Astro-scoped specificity would beat `[data-review-ui]`-prefixed selectors. Computed color is `--er-ink-soft` (verified `rgb(58,51,46)`) with `--er-red-soft` left border.
- Cancel / Leave mark buttons; `Esc` cancels, `Cmd/Ctrl+Enter` submits.
- Entry animation: 220ms slide-down + fade-in.
- All modal code removed (HTML, `.er-modal*` CSS, client-side `openMarkModal` / `closeModal` / `[data-modal-backdrop]`).

## Test plan

- [x] `npm run build:editorialcontrol` clean.
- [x] Playwright: composer opens in sidebar on Mark click; modal DOM is gone; quote color is `rgb(58,51,46)` (not the pre-fix `rgb(224,213,194)`).
- [ ] Eyeball at `/dev/editorial-review/<slug>` — select text, click Mark, verify composer slides in at the top of the rail, quote is readable, save promotes to a normal margin item, cancel dismisses without leaving a trace.
