### PR TITLE
editorial-review: CodeMirror 6 editor with live preview + remove broken kbd hint row

### DIFF
--- a/docs/1.0/001-IN-PROGRESS/editorial-calendar/prd.md
+++ b/docs/1.0/001-IN-PROGRESS/editorial-calendar/prd.md
@@ -148,6 +148,24 @@ Structured markdown file with tables per stage. Each entry includes: title, slug
 - Voice skills (`audiocontrol-voice`, `editorialcontrol-voice`) — required by `/editorial-iterate` and `/editorial-shortform-draft` (Phases 10–11) for voice-consistent drafting and revision
 - `scripts/feature-image/journal.ts` (from feature-image-generator Phase 15) — extracted to `scripts/lib/journal/` in Phase 14 and shared with editorial-review's per-entry record store
 
+## Future Enhancements
+
+- **Visual markdown editor (TipTap / ProseMirror) as an opt-in mode.**
+  The current edit surface on the editorial-review page uses a
+  CodeMirror 6 source editor with a live preview pane and
+  Source / Split / Preview toggles — the modern source-editor
+  shape shipped by Typora, Obsidian, Bear, iA Writer, Ghost.
+  The natural next step is a *Visual* mode that edits the rendered
+  article directly (TipTap on top of `prosemirror-markdown`),
+  keeping markdown as the source of truth with serialization on
+  save. Tradeoffs: markdown round-trip is imperfect for HTML
+  comments, some list shapes, and raw HTML, so the Source mode
+  must remain available as the lossless fallback. Estimated scope:
+  ~1 day of careful implementation; ~200 KB of additional client
+  bundle weight (TipTap + extensions). Not in the critical path;
+  revisit when the operator signals they want proof-style editing
+  on the rendered article.
+
 ## Open Questions
 
 - Exact markdown table format vs structured list entries — tables are more scannable, lists allow more metadata per entry

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,13 @@
       "dependencies": {
         "@astrojs/netlify": "^6.6.4",
         "@astrojs/sitemap": "^3.7.0",
-        "astro": "^5.16.15"
+        "@codemirror/commands": "^6.10.3",
+        "@codemirror/lang-markdown": "^6.5.0",
+        "@codemirror/language": "^6.12.3",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.41.1",
+        "astro": "^5.16.15",
+        "codemirror": "^6.0.2"
       },
       "devDependencies": {
         "@playwright/test": "^1.58.2",
@@ -203,6 +209,147 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.1.tgz",
+      "integrity": "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
+      "integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-css": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.3.1.tgz",
+      "integrity": "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/css": "^1.1.7"
+      }
+    },
+    "node_modules/@codemirror/lang-html": {
+      "version": "6.4.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.11.tgz",
+      "integrity": "sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/css": "^1.1.0",
+        "@lezer/html": "^1.3.12"
+      }
+    },
+    "node_modules/@codemirror/lang-javascript": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz",
+      "integrity": "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-markdown": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-6.5.0.tgz",
+      "integrity": "sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.7.1",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.3.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.2.1",
+        "@lezer/markdown": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
+      "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.5.tgz",
+      "integrity": "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.7.0.tgz",
+      "integrity": "sha512-ZvGm99wc/s2cITtMT15LFdn8aH/aS+V+DqyGq/N5ZlV5vWtH+nILvC2nw0zX7ByNoHHDZ2IxxdW38O0tc5nVHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.37.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.41.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.41.1.tgz",
+      "integrity": "sha512-ToDnWKbBnke+ZLrP6vgTTDScGi5H37YYuZGniQaBzxMVdtCxMrslsmtnOvbPZk4RX9bvkQqnWR/WS/35tJA0qg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.6.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@colors/colors": {
@@ -1267,6 +1414,73 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/css": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.3.tgz",
+      "integrity": "sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/html": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.13.tgz",
+      "integrity": "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/javascript": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
+      "integrity": "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.1.3",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/markdown": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.6.3.tgz",
+      "integrity": "sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
     "node_modules/@mapbox/node-pre-gyp": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-2.0.3.tgz",
@@ -1307,6 +1521,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
     },
     "node_modules/@netlify/ai": {
       "version": "0.3.5",
@@ -5331,6 +5551,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/codemirror": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+      "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
     "node_modules/color": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
@@ -5538,6 +5773,12 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
     },
     "node_modules/cron-parser": {
       "version": "4.9.0",
@@ -11094,6 +11335,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -12566,6 +12813,12 @@
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
       "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
     },
     "node_modules/web-namespaces": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,13 @@
   "dependencies": {
     "@astrojs/netlify": "^6.6.4",
     "@astrojs/sitemap": "^3.7.0",
-    "astro": "^5.16.15"
+    "@codemirror/commands": "^6.10.3",
+    "@codemirror/lang-markdown": "^6.5.0",
+    "@codemirror/language": "^6.12.3",
+    "@codemirror/state": "^6.6.0",
+    "@codemirror/view": "^6.41.1",
+    "astro": "^5.16.15",
+    "codemirror": "^6.0.2"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",

--- a/src/shared/editorial-review-client.ts
+++ b/src/shared/editorial-review-client.ts
@@ -690,28 +690,96 @@ export function initEditorialReview(): void {
   const toggleBtn = q<HTMLButtonElement>('[data-action="toggle-edit"]');
   const cancelEditBtn = q<HTMLButtonElement>('[data-action="cancel-edit"]');
   const saveVersionBtn = q<HTMLButtonElement>('[data-action="save-version"]');
+  const editSourceHost = q<HTMLElement>('[data-edit-source]');
+  const editPreviewHost = q<HTMLElement>('[data-edit-preview]');
+  const editPanes = q<HTMLElement>('[data-edit-panes]');
+  const editModeBtns = Array.from(
+    document.querySelectorAll<HTMLButtonElement>('[data-edit-view]'),
+  );
   let editing = false;
+  let editorHandle: import('./editorial-review-editor').EditorHandle | null = null;
+  let previewDebounce: number | null = null;
 
-  function enterEdit(): void {
+  /** Debounced render of the current source into the preview pane. */
+  function schedulePreview(md: string): void {
+    if (previewDebounce !== null) window.clearTimeout(previewDebounce);
+    previewDebounce = window.setTimeout(async () => {
+      try {
+        const { renderMarkdownToHtml, parseDraftFrontmatter } = await import(
+          '../../scripts/lib/editorial-review/render.js'
+        );
+        const parsed = parseDraftFrontmatter(md);
+        const html = await renderMarkdownToHtml(parsed.body);
+        editPreviewHost.innerHTML = html;
+      } catch (e) {
+        editPreviewHost.innerHTML = `<p class="er-edit-preview-error">Preview failed: ${(e as Error).message}</p>`;
+      }
+    }, 120);
+  }
+
+  /** Flip the three-way Source / Split / Preview toggle. */
+  function setEditView(view: 'source' | 'split' | 'preview'): void {
+    editPanes.dataset.view = view;
+    for (const btn of editModeBtns) {
+      btn.setAttribute('aria-pressed', String(btn.dataset.editView === view));
+    }
+    // If the split / preview pane just became visible with stale
+    // content, refresh it synchronously so the operator never sees
+    // an empty pane.
+    if (view !== 'source' && editorHandle) {
+      schedulePreview(editorHandle.getValue());
+    }
+  }
+
+  for (const btn of editModeBtns) {
+    btn.addEventListener('click', () => {
+      const v = btn.dataset.editView as 'source' | 'split' | 'preview';
+      setEditView(v);
+    });
+  }
+
+  async function enterEdit(): Promise<void> {
     draftEdit.value = state.currentVersion.markdown;
-    draftEdit.hidden = false;
     editToolbar.hidden = false;
     draftBody.classList.add('hidden');
     toggleBtn.textContent = 'View';
     editing = true;
+    // Lazy-import the editor module so the CodeMirror bundle only
+    // loads when the operator actually enters edit mode.
+    const { mountEditor } = await import('./editorial-review-editor.ts');
+    if (editorHandle) editorHandle.destroy();
+    editSourceHost.innerHTML = '';
+    editorHandle = mountEditor({
+      host: editSourceHost,
+      doc: state.currentVersion.markdown,
+      onChange: (md) => {
+        draftEdit.value = md;
+        updateSaveState();
+        if (editPanes.dataset.view !== 'source') schedulePreview(md);
+      },
+      onSave: () => { saveVersionBtn.click(); },
+      onCancel: () => { cancelEditBtn.click(); },
+    });
     updateSaveState();
-    // Scroll the textarea into view — BlogLayout header and feature
-    // image otherwise keep it below the fold on first click.
-    draftEdit.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    draftEdit.focus({ preventScroll: true });
+    // Default view is split — shows what the source will look like
+    // as you type. Operators who want focus switch to Source or Preview.
+    setEditView('split');
+    editToolbar.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    editorHandle.focus();
+    schedulePreview(state.currentVersion.markdown);
   }
 
   function exitEdit(): void {
-    draftEdit.hidden = true;
     editToolbar.hidden = true;
     draftBody.classList.remove('hidden');
     toggleBtn.textContent = 'Edit';
     editing = false;
+    if (editorHandle) {
+      editorHandle.destroy();
+      editorHandle = null;
+    }
+    editSourceHost.innerHTML = '';
+    editPreviewHost.innerHTML = '';
   }
 
   function updateSaveState(): void {
@@ -720,9 +788,11 @@ export function initEditorialReview(): void {
     editHint.textContent = changed ? 'Modified' : 'No changes';
   }
 
-  toggleBtn.addEventListener('click', () => { if (editing) { exitEdit(); } else { enterEdit(); } });
+  toggleBtn.addEventListener('click', () => {
+    if (editing) exitEdit();
+    else void enterEdit();
+  });
   cancelEditBtn.addEventListener('click', exitEdit);
-  draftEdit.addEventListener('input', updateSaveState);
 
   // Double-click anywhere in the rendered draft enters edit mode. This
   // mirrors the comment gesture (select → Mark) with its own shape so
@@ -734,9 +804,9 @@ export function initEditorialReview(): void {
     const target = ev.target;
     if (target instanceof HTMLElement && target.closest('mark.draft-comment-highlight')) return;
     // Clear the double-click text selection the browser made on the way in
-    // — otherwise the Mark button reappears alongside the textarea.
+    // — otherwise the Mark button reappears alongside the editor.
     window.getSelection()?.removeAllRanges();
-    enterEdit();
+    void enterEdit();
   });
 
   saveVersionBtn.addEventListener('click', async () => {

--- a/src/shared/editorial-review-editor.ts
+++ b/src/shared/editorial-review-editor.ts
@@ -1,0 +1,187 @@
+/*
+ * editorial-review-editor.ts — CodeMirror 6 markdown editor for the
+ * review surface's edit mode.
+ *
+ * Not 2005. Replaces a raw <textarea> with a CodeMirror 6 instance
+ * configured for markdown: syntax highlighting (headings, bold,
+ * italic, code, links, lists), soft-wrap, a press-check-desk theme
+ * that reads like a proof rather than a code window, and a tight
+ * keyboard binding for save (Cmd/Ctrl+Enter).
+ *
+ * The client code that manages edit mode only needs two things from
+ * this module: a `mount()` that initializes the editor inside a host
+ * element and returns a handle, and the handle's `setValue()` /
+ * `getValue()` / `focus()` methods.
+ *
+ * Preview rendering is handled by the caller — the editor only emits
+ * `onChange` whenever the document changes, passing the current
+ * markdown source. Keeps this module pure: markdown in, markdown out.
+ */
+
+import { EditorView, keymap, lineNumbers, highlightActiveLine } from '@codemirror/view';
+import { EditorState } from '@codemirror/state';
+import { defaultKeymap, history, historyKeymap } from '@codemirror/commands';
+import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
+import { syntaxHighlighting, HighlightStyle } from '@codemirror/language';
+import { tags } from '@lezer/highlight';
+
+export interface EditorHandle {
+  view: EditorView;
+  getValue: () => string;
+  setValue: (md: string) => void;
+  focus: () => void;
+  destroy: () => void;
+}
+
+export interface MountOptions {
+  /** Host element the editor attaches to. The div gets filled. */
+  host: HTMLElement;
+  /** Initial markdown source. */
+  doc: string;
+  /** Fires on every change with the current full source. */
+  onChange: (md: string) => void;
+  /** Fires on Cmd/Ctrl+Enter. Optional. */
+  onSave?: () => void;
+  /** Fires on Esc. Optional. */
+  onCancel?: () => void;
+}
+
+/**
+ * Syntax-highlighting style tuned for markdown-as-prose. Structural
+ * markers (`#`, `**`, `-`, `>`, `` ` ``) render in a mono face with a
+ * dimmed ink color so they read as annotation rather than body.
+ * Bold / italic render visually as bold / italic in the source —
+ * closer to a typographer's proof than a code window.
+ */
+const pressCheckHighlight = HighlightStyle.define([
+  // Structural / meta tokens — dimmed, mono (via CSS variable).
+  { tag: tags.processingInstruction, color: 'var(--er-faded)', fontFamily: 'var(--er-font-mono)', fontWeight: 500 },
+  { tag: tags.meta, color: 'var(--er-faded-2)' },
+
+  // Headings — scale up + weight via h1/h2/h3/h4 tags.
+  { tag: tags.heading1, color: 'var(--er-ink)', fontSize: '1.6rem', fontWeight: 700, fontFamily: 'var(--er-font-display)', lineHeight: '1.25' },
+  { tag: tags.heading2, color: 'var(--er-ink)', fontSize: '1.3rem', fontWeight: 600, fontFamily: 'var(--er-font-display)', lineHeight: '1.3' },
+  { tag: tags.heading3, color: 'var(--er-ink)', fontSize: '1.1rem', fontWeight: 600, fontFamily: 'var(--er-font-display)' },
+  { tag: tags.heading4, color: 'var(--er-ink)', fontSize: '1rem', fontWeight: 600, fontFamily: 'var(--er-font-display)' },
+
+  // Emphasis renders inline so the source feels like prose.
+  { tag: tags.strong, color: 'var(--er-ink)', fontWeight: 700 },
+  { tag: tags.emphasis, color: 'var(--er-ink)', fontStyle: 'italic' },
+
+  // Links — blue-pencil treatment.
+  { tag: tags.link, color: 'var(--er-proof-blue)', textDecoration: 'underline', textUnderlineOffset: '2px' },
+  { tag: tags.url, color: 'var(--er-proof-blue)', fontFamily: 'var(--er-font-mono)', fontSize: '0.85em' },
+
+  // Inline code + fences.
+  { tag: tags.monospace, color: 'var(--er-ink-soft)', fontFamily: 'var(--er-font-mono)', fontSize: '0.85em' },
+
+  // Block quotes — red-pencil bar handled in CSS; token color stays soft.
+  { tag: tags.quote, color: 'var(--er-ink-soft)', fontStyle: 'italic' },
+
+  // Lists — bullet / number markers.
+  { tag: tags.list, color: 'var(--er-ink)' },
+
+  // Hidden comments (HTML comment syntax) — faded out so they don't shout.
+  { tag: tags.comment, color: 'var(--er-faded-2)', fontStyle: 'italic' },
+]);
+
+/**
+ * Theme tuned to the press-check-desk aesthetic. CodeMirror 6
+ * themes are just `EditorView.theme({...})` — the class hooks are
+ * stable across versions.
+ */
+const pressCheckTheme = EditorView.theme(
+  {
+    '&': {
+      fontFamily: 'var(--er-font-body)',
+      fontSize: '1rem',
+      lineHeight: '1.55',
+      color: 'var(--er-ink)',
+      backgroundColor: 'var(--er-paper)',
+      height: '100%',
+    },
+    '.cm-scroller': {
+      fontFamily: 'var(--er-font-body)',
+      overflow: 'auto',
+      padding: 'var(--er-space-2) 0',
+    },
+    '.cm-content': {
+      padding: '0 var(--er-space-3)',
+      caretColor: 'var(--er-red-pencil)',
+    },
+    '.cm-cursor, .cm-dropCursor': { borderLeftColor: 'var(--er-red-pencil)', borderLeftWidth: '2px' },
+    '.cm-activeLine': { backgroundColor: 'transparent' },
+    '.cm-activeLineGutter': { backgroundColor: 'transparent' },
+    '.cm-gutters': {
+      backgroundColor: 'transparent',
+      color: 'var(--er-faded-2)',
+      border: 'none',
+      fontFamily: 'var(--er-font-mono)',
+      fontSize: '0.65rem',
+    },
+    '.cm-selectionBackground, ::selection': {
+      backgroundColor: 'color-mix(in srgb, var(--er-highlight) 60%, transparent) !important',
+    },
+    '.cm-focused': { outline: 'none' },
+    '.cm-focused .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection': {
+      backgroundColor: 'color-mix(in srgb, var(--er-highlight) 60%, transparent) !important',
+    },
+    '.cm-line': { padding: '0' },
+  },
+  { dark: false },
+);
+
+export function mountEditor(opts: MountOptions): EditorHandle {
+  const state = EditorState.create({
+    doc: opts.doc,
+    extensions: [
+      lineNumbers(),
+      history(),
+      highlightActiveLine(),
+      markdown({ base: markdownLanguage, codeLanguages: [] }),
+      syntaxHighlighting(pressCheckHighlight),
+      pressCheckTheme,
+      EditorView.lineWrapping,
+      keymap.of([
+        {
+          key: 'Mod-Enter',
+          run: () => {
+            opts.onSave?.();
+            return true;
+          },
+        },
+        {
+          key: 'Escape',
+          run: () => {
+            opts.onCancel?.();
+            return true;
+          },
+        },
+        ...defaultKeymap,
+        ...historyKeymap,
+      ]),
+      EditorView.updateListener.of((update) => {
+        if (update.docChanged) {
+          opts.onChange(update.state.doc.toString());
+        }
+      }),
+    ],
+  });
+
+  const view = new EditorView({
+    state,
+    parent: opts.host,
+  });
+
+  return {
+    view,
+    getValue: () => view.state.doc.toString(),
+    setValue: (md: string) => {
+      view.dispatch({
+        changes: { from: 0, to: view.state.doc.length, insert: md },
+      });
+    },
+    focus: () => view.focus(),
+    destroy: () => view.destroy(),
+  };
+}

--- a/src/shared/editorial-review.css
+++ b/src/shared/editorial-review.css
@@ -1149,31 +1149,87 @@ body:has([data-review-ui="longform"]) .site-footer {
   100% { box-shadow: 0 6px 14px rgba(184,54,42,0.4), 0 0 0 3px rgba(245,241,232,0.18); }
 }
 
-/* Edit-mode shell */
+/* Edit-mode shell — CodeMirror 6 source editor plus a live preview
+ * pane, toggled via Source / Split / Preview. The mounted CM instance
+ * is themed in the editor module (editorial-review-editor.ts); this
+ * block wires the layout chrome around it. */
+
 .er-edit-mode {
   background: var(--er-paper-2);
   border-top: var(--er-rule-med);
   padding: var(--er-space-3);
   margin-top: var(--er-space-3);
-}
-.er-edit-mode textarea {
-  width: 100%;
-  min-height: 32rem;
-  font-family: var(--er-font-mono);
-  font-size: 0.85rem;
-  line-height: 1.6;
-  padding: var(--er-space-2);
-  background: var(--er-paper);
-  border: var(--er-rule-thin);
-  color: var(--er-ink);
-  /* Clears the fixed-position strip when scrollIntoView places the
-   * textarea at the top of the viewport. */
   scroll-margin-top: 5rem;
-  resize: vertical;
-  border-radius: 2px;
 }
+
+/* When the edit mode is active, widen BlogLayout's host column
+ * AND collapse its reserved TOC slot so the source/preview panes
+ * can use the full width. BlogLayout uses
+ *   .essay-body-wrap { grid-template-columns: 1fr 14rem }
+ * to reserve space for a TOC on the right. In edit mode we don't
+ * need the TOC column; flattening it frees up 17rem. Also widen
+ * .essay (66rem cap) and .essay-body (34rem cap). Specificity via
+ * :has() + body beats the component-scoped Astro rules without
+ * reaching into BlogLayout internals. 19rem reserved for the
+ * fixed margin rail. */
+body:has(.er-edit-mode:not([hidden])) .essay,
+body:has(.er-edit-mode:not([hidden])) .essay-body {
+  max-width: calc(100vw - 19rem);
+  /* Left-align in edit mode so the content doesn't center under the
+   * fixed margin rail (18rem wide) on the right. The .essay's
+   * `margin: 0 auto` would otherwise split the viewport-minus-rail
+   * remainder on both sides, pulling the preview pane under the rail. */
+  margin-left: 0;
+  margin-right: auto;
+}
+body:has(.er-edit-mode:not([hidden])) .essay-body-wrap {
+  grid-template-columns: 1fr !important;
+}
+body:has(.er-edit-mode:not([hidden])) .toc {
+  display: none;
+}
+
+.er-edit-chrome {
+  display: flex;
+  gap: var(--er-space-2);
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  margin-bottom: var(--er-space-2);
+  padding-bottom: var(--er-space-2);
+  border-bottom: 1px dashed var(--er-faded-2);
+}
+
+/* Source / Split / Preview tabs. Three-way pill; the active state
+ * gets filled ink. */
+.er-edit-modes {
+  display: inline-flex;
+  gap: 0;
+  border: 1px solid var(--er-faded-2);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.er-edit-mode-btn {
+  font-family: var(--er-font-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  padding: 0.35rem 0.7rem;
+  border: 0;
+  border-right: 1px solid var(--er-faded-2);
+  background: transparent;
+  color: var(--er-faded);
+  cursor: pointer;
+  transition: color 120ms ease, background 120ms ease;
+}
+.er-edit-mode-btn:last-child { border-right: 0; }
+.er-edit-mode-btn:hover { color: var(--er-ink); }
+.er-edit-mode-btn[aria-pressed="true"] {
+  background: var(--er-ink);
+  color: var(--er-paper);
+}
+
 .er-edit-actions {
-  margin-top: var(--er-space-2);
   display: flex;
   gap: var(--er-space-1);
   align-items: center;
@@ -1181,9 +1237,121 @@ body:has([data-review-ui="longform"]) .site-footer {
 }
 .er-edit-hint {
   font-family: var(--er-font-mono);
-  font-size: 0.72rem;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   color: var(--er-faded);
   margin-left: var(--er-space-1);
+}
+
+/* Split container. `data-view` drives whether each child pane is
+ * visible; split shows both at 1fr/1fr, source/preview show one.
+ * Height is fixed at a generous reading depth so scroll happens
+ * inside each pane, not the page. */
+.er-edit-panes {
+  display: grid;
+  gap: var(--er-space-2);
+  height: 70vh;
+  min-height: 30rem;
+  border: var(--er-rule-thin);
+  background: var(--er-paper);
+  overflow: hidden;
+}
+.er-edit-panes[data-view="source"]  { grid-template-columns: 1fr 0; }
+.er-edit-panes[data-view="preview"] { grid-template-columns: 0 1fr; }
+.er-edit-panes[data-view="split"]   { grid-template-columns: 1fr 1fr; }
+.er-edit-panes[data-view="source"]  .er-edit-preview { display: none; }
+.er-edit-panes[data-view="preview"] .er-edit-source  { display: none; }
+
+.er-edit-source {
+  overflow: hidden;
+  height: 100%;
+  border-right: 1px dashed var(--er-faded-2);
+}
+.er-edit-panes[data-view="source"] .er-edit-source  { border-right: 0; }
+.er-edit-panes[data-view="preview"] .er-edit-source { border-right: 0; }
+
+/* Let the CodeMirror instance fill its host. */
+.er-edit-source .cm-editor { height: 100%; }
+.er-edit-source .cm-editor.cm-focused { outline: none; }
+
+/* Preview pane. Read-only rendered HTML that mirrors the published
+ * layout as close as we can match it without re-importing the full
+ * BlogLayout typography. */
+.er-edit-preview {
+  overflow: auto;
+  padding: var(--er-space-3) var(--er-space-4);
+  font-family: var(--er-font-body);
+  line-height: 1.65;
+  color: var(--er-ink);
+  background: var(--er-paper);
+}
+.er-edit-preview h1,
+.er-edit-preview h2,
+.er-edit-preview h3,
+.er-edit-preview h4 {
+  font-family: var(--er-font-display);
+  color: var(--er-ink);
+  letter-spacing: -0.01em;
+  margin: 1.6em 0 0.4em;
+  line-height: 1.2;
+}
+.er-edit-preview h1 { font-size: 2rem;   font-weight: 700; }
+.er-edit-preview h2 { font-size: 1.4rem; font-weight: 600; }
+.er-edit-preview h3 { font-size: 1.15rem; font-weight: 600; }
+.er-edit-preview h4 { font-size: 1rem;   font-weight: 600; }
+.er-edit-preview p  { margin: 0 0 1em; }
+.er-edit-preview ul, .er-edit-preview ol { padding-left: 1.5em; margin: 0 0 1em; }
+.er-edit-preview li { margin-bottom: 0.35em; }
+.er-edit-preview blockquote {
+  border-left: 3px solid var(--er-red-soft);
+  padding: 0.2em 1em;
+  margin: 0 0 1em;
+  color: var(--er-ink-soft);
+  font-style: italic;
+}
+.er-edit-preview code {
+  font-family: var(--er-font-mono);
+  font-size: 0.85em;
+  background: var(--er-paper-2);
+  padding: 0.1em 0.35em;
+  border-radius: 2px;
+  color: var(--er-ink-soft);
+}
+.er-edit-preview pre {
+  background: var(--er-paper-2);
+  padding: var(--er-space-2);
+  overflow-x: auto;
+  border: 1px solid var(--er-faded-2);
+  border-radius: 2px;
+  font-family: var(--er-font-mono);
+  font-size: 0.85em;
+  margin: 0 0 1em;
+}
+.er-edit-preview hr {
+  border: 0;
+  border-top: 1px solid var(--er-faded-2);
+  margin: 2em 0;
+}
+.er-edit-preview a {
+  color: var(--er-proof-blue);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.er-edit-preview-error {
+  font-family: var(--er-font-mono);
+  font-size: 0.85rem;
+  color: var(--er-red-pencil);
+  padding: var(--er-space-2);
+}
+
+/* Phone: stack Split vertically. */
+@media (max-width: 900px) {
+  .er-edit-panes[data-view="split"] {
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr 1fr;
+  }
+  .er-edit-source { border-right: 0; border-bottom: 1px dashed var(--er-faded-2); }
 }
 
 /* ---------- Margin-note composer ----------

--- a/src/shared/editorial-review.css
+++ b/src/shared/editorial-review.css
@@ -1295,25 +1295,6 @@ body:has([data-review-ui="longform"]) .site-footer {
   margin-top: var(--er-space-1);
 }
 
-[data-review-ui="longform"] .er-marginalia-composer-hint {
-  font-family: var(--er-font-mono);
-  font-size: 0.58rem;
-  letter-spacing: 0.1em;
-  color: var(--er-faded-2);
-  margin: 0.35rem 0 0;
-  text-align: right;
-}
-[data-review-ui="longform"] .er-marginalia-composer-hint kbd {
-  font-family: var(--er-font-mono);
-  font-size: 0.58rem;
-  padding: 0.1rem 0.3rem;
-  border: 1px solid var(--er-faded-2);
-  border-radius: 2px;
-  color: var(--er-faded);
-  margin: 0 0.1rem;
-  background: transparent;
-}
-
 /* ---------- Toast ---------- */
 
 .er-toast {

--- a/src/sites/editorialcontrol/pages/dev/editorial-review/[slug].astro
+++ b/src/sites/editorialcontrol/pages/dev/editorial-review/[slug].astro
@@ -218,9 +218,6 @@ function stateLabel(state?: string): string {
           <button type="button" class="er-btn er-btn-small" data-action="cancel-comment">Cancel</button>
           <button type="button" class="er-btn er-btn-small er-btn-primary" data-action="submit-comment">Leave mark</button>
         </div>
-        <p class="er-marginalia-composer-hint">
-          <kbd>⌘</kbd><kbd>↵</kbd> save · <kbd>esc</kbd> cancel
-        </p>
       </section>
 
       <ol class="er-marginalia-list" data-sidebar-list></ol>
@@ -237,12 +234,13 @@ function stateLabel(state?: string): string {
         <dl>
           <dt><kbd>e</kbd> / dbl-click</dt><dd>toggle edit mode</dd>
           <dt>select text</dt><dd>leave a margin note</dd>
+          <dt><kbd>⌘</kbd><kbd>↵</kbd> / <kbd>ctrl</kbd><kbd>↵</kbd></dt><dd>save margin note (in composer)</dd>
           <dt><kbd>a</kbd></dt><dd>approve</dd>
           <dt><kbd>i</kbd></dt><dd>iterate</dd>
           <dt><kbd>r</kbd></dt><dd>reject</dd>
           <dt><kbd>j</kbd> / <kbd>k</kbd></dt><dd>next / previous margin note</dd>
           <dt><kbd>?</kbd></dt><dd>this panel</dd>
-          <dt><kbd>esc</kbd></dt><dd>close</dd>
+          <dt><kbd>esc</kbd></dt><dd>close / cancel composer</dd>
         </dl>
         <p class="er-shortcuts-footer">Press <kbd>?</kbd> anytime.</p>
       </div>

--- a/src/sites/editorialcontrol/pages/dev/editorial-review/[slug].astro
+++ b/src/sites/editorialcontrol/pages/dev/editorial-review/[slug].astro
@@ -123,12 +123,29 @@ function stateLabel(state?: string): string {
       <div class="er-draft-frame">
         <div id="draft-body" data-draft-body title="Double-click to edit · select text to leave a margin note" set:html={renderedHtml}></div>
         <div class="er-edit-mode" data-edit-toolbar hidden>
-          <textarea id="draft-edit" data-draft-edit></textarea>
-          <div class="er-edit-actions">
-            <button class="er-btn er-btn-primary" data-action="save-version" type="button">Save as new version</button>
-            <button class="er-btn" data-action="cancel-edit" type="button">Cancel</button>
-            <span class="er-edit-hint" data-edit-hint></span>
+          <div class="er-edit-chrome">
+            <div class="er-edit-modes" role="tablist" aria-label="Editor mode">
+              <button class="er-edit-mode-btn" data-edit-view="source" type="button" aria-pressed="true">Source</button>
+              <button class="er-edit-mode-btn" data-edit-view="split" type="button" aria-pressed="false">Split</button>
+              <button class="er-edit-mode-btn" data-edit-view="preview" type="button" aria-pressed="false">Preview</button>
+            </div>
+            <div class="er-edit-actions">
+              <button class="er-btn er-btn-primary" data-action="save-version" type="button">Save as new version</button>
+              <button class="er-btn" data-action="cancel-edit" type="button">Cancel</button>
+              <span class="er-edit-hint" data-edit-hint></span>
+            </div>
           </div>
+          <div class="er-edit-panes" data-edit-panes data-view="source">
+            <!-- Source pane: CodeMirror 6 mounts inside this div on toggle-to-edit. -->
+            <div class="er-edit-source" data-edit-source aria-label="Markdown source"></div>
+            <!-- Preview pane: live-rendered HTML of the current source, read-only. -->
+            <div class="er-edit-preview" data-edit-preview aria-label="Rendered preview"></div>
+          </div>
+          <!-- Hidden backing textarea so the existing save pipeline (which
+               reads from #draft-edit) keeps working without rewiring. The
+               CodeMirror instance syncs its value into this element on
+               every change. -->
+          <textarea id="draft-edit" data-draft-edit hidden></textarea>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

Two related edit-surface improvements on the editorial-review page.

### 1. Drop the broken kbd hint row from the margin-note composer

The `⌘ ↵ save · esc cancel` hint strip under the composer's Cancel / Leave mark buttons was rendering as a broken staircase (each `<kbd>` had its own inline-block padding; right-aligning pills with implicit baseline produced misaligned groups). Also duplicated information the visible buttons already carry. Removed HTML + CSS; moved the composer-specific bindings (`⌘↵` / `ctrl↵` save, `esc` cancel) into the `/?` shortcuts overlay.

### 2. Replace the raw textarea with a CodeMirror 6 markdown editor + live preview

The edit-mode pane was a plain `<textarea>` in monospace — a 2005-vintage UX. Replaced with CodeMirror 6 + `@codemirror/lang-markdown`, a live preview pane driven by the existing `renderMarkdownToHtml` pipeline, and a three-way toggle: **Source / Split / Preview**. The shape shipped by Typora, Obsidian, Bear, iA Writer, Ghost — modern markdown-editor pattern.

**Aesthetic choices:**
- CodeMirror theme tuned to the press-check desk: Newsreader body, Fraunces for headings, JetBrains Mono for structural tokens, red-pencil caret.
- Markdown syntax highlighting renders **bold** inline bold, *italic* inline italic, headings scaled with weight, code/fences in mono — source reads like a typographer's proof.
- Split-view widens the host column by overriding BlogLayout's `.essay / .essay-body / .essay-body-wrap` max-widths via `body:has()` when edit mode is active. Flattens the reserved TOC grid slot. Left-aligns so content doesn't center under the fixed margin rail.

**Implementation:**
- Dynamic import of `editorial-review-editor.ts` on first Edit — CodeMirror only loads when needed.
- Hidden `#draft-edit` textarea retained as backing store so the save pipeline is unchanged.
- Live preview via 120ms-debounced render.
- `Cmd/Ctrl+Enter` saves, `Esc` cancels. Dblclick-to-edit preserved.

**Deps:** `codemirror`, `@codemirror/lang-markdown`, `@codemirror/view`, `@codemirror/state`, `@codemirror/language`, `@codemirror/commands`.

**PRD updated** with a Future Enhancements section noting the TipTap/ProseMirror visual-mode path as opt-in.

## Test plan

- [x] `npm run build:editorialcontrol` clean.
- [x] Playwright: Edit click mounts CodeMirror (`.cm-editor` present), Source/Split/Preview toggle works, preview pane renders the article H1 + body.
- [x] Split view pane width 776px at 1200px viewport (up from 504px before widening).
- [x] Margin-note composer: no `.er-marginalia-composer-hint` element, layout clean under Cancel / Leave mark.
- [ ] Eyeball — verify Source typography reads like prose (not code), Preview renders match the published view, Cmd+Enter saves, Esc cancels.
