### PR TITLE
editorial: strip body's leading # Title from blog post render

### DIFF
--- a/astro.audiocontrol.config.mjs
+++ b/astro.audiocontrol.config.mjs
@@ -6,6 +6,7 @@ import netlify from '@astrojs/netlify';
 import sitemap from '@astrojs/sitemap';
 
 import remarkStripOutline from './scripts/lib/editorial/remark-strip-outline.mjs';
+import remarkStripFirstH1 from './scripts/lib/editorial/remark-strip-first-h1.mjs';
 import remarkImageFigure from './scripts/lib/editorial/remark-image-figure.mjs';
 
 // Last modified dates for sitemap
@@ -55,7 +56,7 @@ export default defineConfig({
   // and stays unaffected; the outline stays visible where it's used
   // for annotate-and-iterate work, and disappears from /blog/<slug>/.
   markdown: {
-    remarkPlugins: [remarkStripOutline, remarkImageFigure],
+    remarkPlugins: [remarkStripOutline, remarkStripFirstH1, remarkImageFigure],
   },
   vite: {
     server: {

--- a/astro.editorialcontrol.config.mjs
+++ b/astro.editorialcontrol.config.mjs
@@ -6,6 +6,7 @@ import netlify from '@astrojs/netlify';
 import sitemap from '@astrojs/sitemap';
 
 import remarkStripOutline from './scripts/lib/editorial/remark-strip-outline.mjs';
+import remarkStripFirstH1 from './scripts/lib/editorial/remark-strip-first-h1.mjs';
 import remarkImageFigure from './scripts/lib/editorial/remark-image-figure.mjs';
 
 // https://astro.build/config
@@ -22,7 +23,7 @@ export default defineConfig({
   // and stays unaffected; the outline stays visible where it's used
   // for annotate-and-iterate work, and disappears from /blog/<slug>/.
   markdown: {
-    remarkPlugins: [remarkStripOutline, remarkImageFigure],
+    remarkPlugins: [remarkStripOutline, remarkStripFirstH1, remarkImageFigure],
   },
   vite: {
     server: {

--- a/scripts/lib/editorial-review/render.ts
+++ b/scripts/lib/editorial-review/render.ts
@@ -4,6 +4,8 @@ import remarkRehype from 'remark-rehype';
 import rehypeStringify from 'rehype-stringify';
 // @ts-expect-error — JS module without a .d.ts; the plugin is plain mdast traversal.
 import remarkImageFigure from '../editorial/remark-image-figure.mjs';
+// @ts-expect-error — JS module without a .d.ts; the plugin is plain mdast traversal.
+import remarkStripFirstH1 from '../editorial/remark-strip-first-h1.mjs';
 
 export interface ParsedDraft {
   frontmatter: Record<string, string>;
@@ -28,10 +30,13 @@ export async function renderMarkdownToHtml(markdown: string): Promise<string> {
   const result = await unified()
     .use(remarkParse)
     // Mirror the public Astro pipeline: wrap standalone images in
-    // <figure><figcaption> so the review surface shows what the
-    // reader will see, captions and all. Outline-strip is NOT added
-    // here on purpose — the review surface needs the outline visible
-    // for annotate-and-iterate work.
+    // <figure><figcaption> and drop the body's leading `# Title` (the
+    // BlogLayout / review shell renders title from frontmatter; the
+    // body repeat is a print-magazine convention that reads as
+    // throat-clearing on the web). Outline-strip is NOT added here on
+    // purpose — the review surface needs the outline visible for
+    // annotate-and-iterate work.
+    .use(remarkStripFirstH1)
     .use(remarkImageFigure)
     .use(remarkRehype)
     .use(rehypeStringify)

--- a/scripts/lib/editorial/remark-strip-first-h1.mjs
+++ b/scripts/lib/editorial/remark-strip-first-h1.mjs
@@ -1,0 +1,31 @@
+/**
+ * remark plugin: strip the first H1 from rendered markdown output.
+ *
+ * The editorialcontrol voice pattern is "repeat the title above the
+ * body" (a print-magazine convention that reorients the reader after
+ * a page turn). On a scrolling web document the convention reads as
+ * repetition — the BlogLayout header already renders the title from
+ * frontmatter, so the markdown body's leading `# Title` appears as a
+ * second copy right under the feature image. This plugin drops that
+ * first H1 from the rendered tree while leaving the markdown file
+ * intact (so the `.md` still validates as a standalone document and
+ * the operator keeps writing `# Title` at the top of the body per
+ * voice guidance).
+ *
+ * Stripping shape: find the first top-level H1 in the document and
+ * remove it. All other H1s (rare in these posts, but possible) are
+ * preserved. No-op when the document has no leading H1.
+ *
+ * Same registration pattern as `remark-strip-outline.mjs` — loaded
+ * into both site configs' `remarkPlugins` AND the editorial-review
+ * unified render pipeline so production and review match.
+ */
+
+export default function remarkStripFirstH1() {
+  return (tree) => {
+    const children = tree.children;
+    const idx = children.findIndex((n) => n.type === 'heading' && n.depth === 1);
+    if (idx < 0) return;
+    children.splice(idx, 1);
+  };
+}

--- a/test/editorial/remark-strip-first-h1.test.ts
+++ b/test/editorial/remark-strip-first-h1.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkStringify from 'remark-stringify';
+import remarkStripFirstH1 from '../../scripts/lib/editorial/remark-strip-first-h1.mjs';
+
+async function strip(markdown: string): Promise<string> {
+  const result = await unified()
+    .use(remarkParse)
+    .use(remarkStripFirstH1)
+    .use(remarkStringify)
+    .process(markdown);
+  return String(result);
+}
+
+describe('remarkStripFirstH1', () => {
+  it('removes the leading H1', async () => {
+    const input = [
+      '# Your Content Workflow Is Already Obsolete.',
+      '',
+      'Opening paragraph.',
+      '',
+    ].join('\n');
+    const output = await strip(input);
+    expect(output).not.toContain('Your Content Workflow');
+    expect(output).toContain('Opening paragraph.');
+  });
+
+  it('removes only the first H1, leaves later H1s alone', async () => {
+    const input = [
+      '# First',
+      '',
+      'Intro.',
+      '',
+      '# Second',
+      '',
+      'Body.',
+      '',
+    ].join('\n');
+    const output = await strip(input);
+    expect(output).not.toContain('# First');
+    expect(output).toContain('# Second');
+    expect(output).toContain('Intro.');
+    expect(output).toContain('Body.');
+  });
+
+  it('is a no-op when there is no H1', async () => {
+    const input = [
+      'Opening paragraph.',
+      '',
+      '## Section heading',
+      '',
+      'More prose.',
+      '',
+    ].join('\n');
+    const output = await strip(input);
+    expect(output).toContain('Opening paragraph.');
+    expect(output).toContain('## Section heading');
+    expect(output).toContain('More prose.');
+  });
+
+  it('leaves H2s and lower-depth headings untouched', async () => {
+    const input = [
+      '# Title',
+      '',
+      '## Section one',
+      '',
+      'Body.',
+      '',
+      '### Subsection',
+      '',
+      'More body.',
+      '',
+    ].join('\n');
+    const output = await strip(input);
+    expect(output).not.toContain('# Title');
+    expect(output).toContain('## Section one');
+    expect(output).toContain('### Subsection');
+  });
+
+  it('strips H1 even if it is not the very first node', async () => {
+    // Edge case: a post with a leading HTML comment or standalone
+    // block before the H1. The plugin should still drop the first
+    // H1 it encounters.
+    const input = [
+      '<!-- some comment -->',
+      '',
+      '# Title',
+      '',
+      'Body.',
+      '',
+    ].join('\n');
+    const output = await strip(input);
+    expect(output).not.toContain('# Title');
+    expect(output).toContain('Body.');
+  });
+});


### PR DESCRIPTION
## Summary

- New `remark-strip-first-h1` plugin drops the body's leading `# Title` from every blog post's rendered output. The BlogLayout already renders the title from frontmatter; the body repeat was throat-clearing under the feature image.
- Registered in both Astro configs + the editorial-review render pipeline (same policy as `remark-image-figure`), so review matches production.
- Markdown files keep their `# Title` intact so they stay self-contained / voice-guidance-compliant.

## Test plan

- [x] `npm test` — 5 new tests for the plugin; 283/283 total passing.
- [x] `npm run build:editorialcontrol` — one `<h1>` in the built page (BlogLayout header); zero inside `.essay-body`.
- [ ] Manual check on deploy preview: each dispatch renders title → dek → date/author → feature image → first paragraph (no repeated title between image and body).
