### PR TITLE
editorialcontrol: tailpiece replaces floating rule-double on desk page

### DIFF
--- a/src/sites/editorialcontrol/pages/blog/index.astro
+++ b/src/sites/editorialcontrol/pages/blog/index.astro
@@ -71,7 +71,10 @@ const formatDate = (iso: string): string => {
       ))}
     </ol>
 
-    <hr class="rule-double" />
+    <aside class="desk-tailpiece" aria-hidden="true">
+      <p class="tailpiece-mark">◆ ◆ ◆</p>
+      <p class="tailpiece-note">More dispatches in pre-press.</p>
+    </aside>
 
     <aside class="dispatch-card">
       <p class="dispatch-kicker">The dispatch</p>
@@ -227,9 +230,39 @@ const formatDate = (iso: string): string => {
     border: 1px solid hsl(var(--border));
   }
 
+  /* ---- Tailpiece (printer's mark closing the desk listing) ---- */
+  .desk-tailpiece {
+    text-align: center;
+    margin: 3.5rem 0 0 0;
+    padding: 0;
+  }
+
+  .tailpiece-mark {
+    /* Three diamonds spaced apart read as an editorial section break.
+     * The diamond is the site's brand mark; the trio + chartreuse +
+     * mono register make the role unambiguous. */
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    letter-spacing: 0.65em;
+    color: hsl(var(--primary));
+    margin: 0 0 1.1rem 0;
+    /* letter-spacing adds trailing space on the right side; offset for true centering */
+    padding-left: 0.65em;
+    line-height: 1;
+  }
+
+  .tailpiece-note {
+    font-family: var(--font-display);
+    font-style: italic;
+    font-size: 1.05rem;
+    line-height: 1.4;
+    color: hsl(var(--muted-foreground));
+    margin: 0;
+  }
+
   /* ---- Dispatch card ---- */
   .dispatch-card {
-    padding: 2rem 0 0 0;
+    padding: 3rem 0 0 0;
   }
 
   .dispatch-kicker {


### PR DESCRIPTION
## Summary

Replaces the floating `<hr class="rule-double" />` at the bottom of the editorialcontrol desk listing (`/blog/`) with a magazine-style tailpiece — three chartreuse `◆` diamonds in mono spacing plus a single italic line ("More dispatches in pre-press.") — so the section transition reads as intentional editorial typography instead of an accidental cluster of three hairlines.

Homepage's `rule-double` usage is intentionally unchanged: that one sits between a populated marginalia rail and the dispatch card, so it has visual rhythm on either side; the desk page didn't.

## Before

Last post item's `border-bottom` hairline, ~3rem of dead air, then the `rule-double`'s two parallel hairlines floating between the listing and the dispatch CTA — three rules, no narrative weight.

## After

```
[last post hairline]

         ◆   ◆   ◆
   More dispatches in pre-press.

THE DISPATCH (kicker)
Want new issues delivered by hand?
[Write to the editor →]
```

The diamond is the site's brand mark (homepage tagline, issue stamp). Three diamonds spaced apart reads as an editorial section break and stays inside the existing register.

## Test plan

- [ ] Open `/blog/` on the editorialcontrol deploy preview — confirm the cluster of lines is gone and the tailpiece sits between the last post and the "Want new issues delivered by hand?" CTA.
- [ ] Verify the tailpiece is centered under all four current dispatches.
- [ ] Verify the homepage at `/` still renders the existing rule-double + dispatch CTA pair correctly (no regression).
- [ ] Lighthouse / view-source check that `aria-hidden="true"` on the tailpiece keeps it out of the accessibility tree.
