### PR TITLE
stackcontrol.org — homepage design pass (THE METHOD section, VFD ordinals) + copy

### DIFF
--- a/docs/1.0/001-IN-PROGRESS/stackcontrol-site/messaging-copy-deck.md
+++ b/docs/1.0/001-IN-PROGRESS/stackcontrol-site/messaging-copy-deck.md
@@ -12,7 +12,7 @@ Decided via operator Q&A during the messaging pass:
    named for what it is. **No mention of dw-lifecycle or deskwork.** Don't advertise the
    rebuild / flux.
 2. **Center of gravity — the babysitter premise + the industrial-process thesis**
-   (craftsman → industrialist). The differentiators (the audit barrage / "stochastic
+   (craftsman → industrialist). The differentiators (multi-agent audit / "stochastic
    correctness", scope discovery) are *talked about* as evidence — not enthroned as the headline.
 3. **Voice — bring the visceral frame onto the homepage, anchored by one sharp hero line.**
    ("Both" of: bring-it + one-spark.)
@@ -47,12 +47,12 @@ rail node in this treatment.)
 *Alt:* Industrial discipline for coding agents.
 
 ### Hero
-- **Kicker:** `stack-control · a claude code plugin`
+- **Kicker:** `stack-control · an agent plugin`
 - **H1:** Coding agents need a *babysitter*.  *(em word `babysitter` takes the cyan glow)*
 - **Lede:**
-  > Coding agents are insane, hyperintelligent toddlers — they lie, they get bored, and they cut
-  > corners the second you stop watching. **stack-control** is the babysitter: a Claude Code plugin
-  > that runs every change down an industrial line — heavy design up front, implementation fanned
+  > Coding agents are insane, hyperintelligent toddlers — they lie, they get bored, and they shove
+  > beans up their nose the second you stop watching. **stack-control** is the babysitter: an agent plugin
+  > that runs every change down an assembly line — heavy design up front, implementation fanned
   > out across agents at once, and independent audits on every diff, so correctness never rides on
   > how much attention you had to spare.
 - **CTAs:** `Read the devlog →` · `What it does`
@@ -63,7 +63,7 @@ Four cards in the existing `NN / NAME` + blurb idiom:
   changes, what stays, what's explicitly out." · `$ /stack-control:define`
 - **02 Implement** — "Tasks are delegated to specialized subagents and committed at clean task
   boundaries — never one giant blob." · `$ /stack-control:implement`
-- **03 Audit** — "Every task gets a cross-model audit barrage — multiple reviewers fired in
+- **03 Audit** — "Every task gets a multi-agent audit — multiple reviewers fired in
   parallel against the diff, findings triaged." · *(no command — automatic)*
 - **04 Repeat** — "Audit findings point implementation back to the happy path. Run Implement →
   Audit until the diff comes back clean." · *(no command — the loop)*
@@ -84,7 +84,7 @@ Four cards in the existing `NN / NAME` + blurb idiom:
 
 ### SEO (`<Layout>` props)
 - **Title:** `stackcontrol.org — a babysitter for your coding agents`
-- **Description:** `stack-control is a Claude Code plugin that turns agentic coding into an
+- **Description:** `stack-control is an agent plugin that turns agentic coding into an
   industrial process: heavy design up front, hands-off implementation fanned across agents, and
   multi-model audits on every change.`
 
@@ -93,7 +93,7 @@ Four cards in the existing `NN / NAME` + blurb idiom:
 ## Status
 - Phase grid (4 cards) + commands + `PhaseRail` (4 nodes): **applied**.
 - Tagline, hero, What/Why/How, SEO: **applied** (this pass).
-- `DESIGN-SYSTEM.md` §6/§7 vocabulary (control-plane → babysitter / industrial line / loop):
+- `DESIGN-SYSTEM.md` §6/§7 vocabulary (control-plane → babysitter / assembly line / loop):
   **updated in the same change**.
 - Homepage messaging committed in `0d8474c`; namespace `/stack-control:` confirmed.
 - Published devlog post `standing-up-a-site-with-its-own-lifecycle` **reframed** to stack-control +

--- a/src/sites/stackcontrol/DESIGN-SYSTEM.md
+++ b/src/sites/stackcontrol/DESIGN-SYSTEM.md
@@ -111,6 +111,13 @@ Settled patterns that encode design rules beyond single tokens.
 - **`.rule-single`** — single hairline top border, `margin: 1.5rem 0`.
 - **`.rule-accent`** — `var(--rule-medium)` (2px) cyan top border, `width: 3rem` (no glow).
 - **Phase rail** — see `components/PhaseRail.astro` (§6). The signature device.
+- **VFD readout (`.stage-ord`, `pages/index.astro`)** — the ordinal "tubes" in THE METHOD section: a
+  filled cyan digit with a three-layer bloom, seated in a darkened glass panel (radial cyan-tint
+  background, inset phosphor glow, hairline cyan bezel, multiply-blended scanlines), surging on
+  hover. A cyan vacuum-fluorescent / oscilloscope-phosphor reading — never amber nixie (that breaks
+  the mono-cyan rule); also a nod to vintage sampler/synth displays.
+- **The Method flow (`.method-flow` / `.stage` / `.stage-arrow`)** — three numbered stages joined by
+  cyan flow arrows; the assembly-line thesis made literal. Stacks vertically on mobile.
 - **Telemetry ticker** — see `components/Ticker.astro` (§6).
 - **Body grid + scanline** — see §4 (lives in the Layout's global style).
 
@@ -121,8 +128,9 @@ The `@keyframes ticker` (translateX 0 → -50%) and `.card-glow` come from the s
 ## 6. Components
 
 - **`components/Header.astro`** — sticky, blurred, hairline-bottom site header. Wordmark + mono nav
-  (Product / Devlog / About) with a cyan underline-reveal on hover and an `active` state derived
-  from `Astro.url.pathname`.
+  (Method / Product / Devlog / About — same-page jump anchors plus the Devlog page) with a cyan
+  underline-reveal on hover and an `active` state derived from `Astro.url.pathname`. On ≤560px the
+  nav wraps to its own full-width line below the wordmark (two-line header) rather than overflowing.
 - **`components/Footer.astro`** — wordmark + tagline, sibling links (audiocontrol.org,
   editorialcontrol.org), system links, mono copyline. Imports `Logo`.
 - **`components/Logo.astro`** — the wordmark `stackcontrol` + cyan separating `.` + muted `org`.
@@ -130,8 +138,10 @@ The `@keyframes ticker` (translateX 0 → -50%) and `.card-glow` come from the s
 - **`components/PhaseRail.astro`** — **the signature structural device.** Four connected nodes
   (Define → Implement → Audit → Repeat) on a hairline track with a cyan-tinted center.
   Props: `active?: number` (cyan-lit glowing node), `variant?: 'labeled' | 'divider'`,
-  `phases?: Phase[]`. `labeled` shows ordinal over uppercase name (hero spine); `divider` shows the
-  name alone and is `aria-hidden` (section-divider echo).
+  `phases?: Phase[]`. The `labeled` variant (ordinal over uppercase name) renders **beneath the
+  lifecycle phase cards** in THE LIFECYCLE section — the loop visualized below its own cards. (The
+  hero leads with the babysitter hook; THE METHOD section carries the thesis.) The `divider` variant
+  is currently unused on the homepage.
 - **`components/Ticker.astro`** — the telemetry status bar: a scrolling mono uppercase strip of
   system metadata with a blinking cyan "live" dot, duplicated track for a seamless loop. Rendered
   via the Layout's `banner` slot (above the sticky header). Motion respects
@@ -152,12 +162,15 @@ The `@keyframes ticker` (translateX 0 → -50%) and `.card-glow` come from the s
   site's organizing metaphor and its signature visual device. Define happens once up front;
   Implement and Audit repeat until the diff is clean. Audit carries no command — it fires
   automatically on the implement hook; Repeat is the loop.
-- **Babysitter / industrial line** — the homepage framing (supersedes the earlier "control plane"
+- **Babysitter / assembly line** — the homepage framing (supersedes the earlier "control plane"
   language). Coding agents are "insane, hyperintelligent toddlers" that need supervision;
-  stack-control is the babysitter that runs every change down an **industrial line** — heavy design
-  up front, hands-off parallel implementation, mechanized multi-model audit. The differentiators
-  (the audit barrage / "stochastic correctness", scope discovery) are evidence for the thesis, not
+  stack-control is the babysitter that runs every change down an **assembly line** — heavy design
+  up front, hands-off parallel implementation, mechanized multi-agent audit. The differentiators
+  (multi-agent audit / "stochastic correctness", scope discovery) are evidence for the thesis, not
   the headline. Full copy + rationale: `docs/1.0/001-IN-PROGRESS/stackcontrol-site/messaging-copy-deck.md`.
+- **The Method** — the homepage's three-move thesis, its own section `[ 01 ]` (before THE LIFECYCLE):
+  **front-load design → invest in tooling → industrialize production**, rendered as VFD-readout
+  stages. Page order: METHOD `[ 01 ]` → LIFECYCLE `[ 02 ]` → WHAT/WHY/HOW `[ 03 ]` → DEVLOG `[ 04 ]`.
 
 ---
 

--- a/src/sites/stackcontrol/components/Header.astro
+++ b/src/sites/stackcontrol/components/Header.astro
@@ -13,7 +13,8 @@ const isActive = (href: string) =>
       <Logo variant="header" />
     </a>
     <nav class="main-nav" aria-label="Primary">
-      <a href="/#product" class:list={[{ active: false }]}>Product</a>
+      <a href="/#method">Method</a>
+      <a href="/#product">Product</a>
       <a href="/blog/" class:list={[{ active: isActive('/blog') }]}>Devlog</a>
       <a href="/#how">About</a>
     </nav>
@@ -75,7 +76,13 @@ const isActive = (href: string) =>
   .main-nav a:hover::after,
   .main-nav a.active::after { transform: scaleX(1); }
 
-  @media (max-width: 600px) {
-    .main-nav { gap: 1.1rem; font-size: 0.6875rem; }
+  @media (max-width: 560px) {
+    .header-row { flex-wrap: wrap; row-gap: 0.85rem; }
+    .main-nav {
+      flex-basis: 100%;
+      justify-content: space-between;
+      gap: 0.5rem;
+      font-size: 0.6875rem;
+    }
   }
 </style>

--- a/src/sites/stackcontrol/pages/index.astro
+++ b/src/sites/stackcontrol/pages/index.astro
@@ -16,7 +16,7 @@ const phases: Phase[] = [
     ord: '01',
     name: 'Define',
     blurb:
-      "An interview captures the problem and the scope before any code moves — what changes, what stays, what's explicitly out.",
+      "This is where the work goes. You design the change exhaustively before any code is written — the problem, the scope, what's in and what's explicitly out.",
     cmd: '/stack-control:define',
   },
   {
@@ -30,7 +30,7 @@ const phases: Phase[] = [
     ord: '03',
     name: 'Audit',
     blurb:
-      'Every task gets a cross-model audit barrage — multiple reviewers fired in parallel against the diff, findings triaged.',
+      'Every task gets a multi-agent audit — multiple reviewers fired in parallel against the diff, findings triaged.',
     cmd: '',
   },
   {
@@ -64,20 +64,20 @@ function fmt(dateStr: string): string {
 
 <Layout
   title="stackcontrol.org — a babysitter for your coding agents"
-  description="stack-control is a Claude Code plugin that turns agentic coding into an industrial process: heavy design up front, hands-off implementation fanned across agents, and multi-model audits on every change."
+  description="stack-control is an agent plugin that turns agentic coding into an industrial process: heavy design up front, hands-off implementation fanned across agents, and multi-model audits on every change."
 >
   <Ticker slot="banner" />
 
   {/* ============ HERO ============ */}
   <section class="hero site-container">
-    <p class="kicker">stack-control · a claude code plugin</p>
+    <p class="kicker">stack-control · an agent plugin</p>
     <h1 class="hero-title">Coding agents need a <em>babysitter</em>.</h1>
     <p class="lede">
-      Coding agents are insane, hyperintelligent toddlers — they lie, they get bored, and they cut
-      corners the second you stop watching.
+      Coding agents are insane, hyperintelligent toddlers — they lie, they get bored, and they shove
+      beans up their nose the second you stop watching.
       <span class="lede-muted">
-        <strong>stack-control</strong> is the babysitter: a Claude Code plugin that runs every
-        change down an industrial line — heavy design up front, implementation fanned out across
+        <strong>stack-control</strong> is the babysitter: an agent plugin that runs every
+        change down an assembly line — heavy design up front, implementation fanned out across
         agents at once, and independent audits on every diff, so correctness never rides on how much
         attention you had to spare.
       </span>
@@ -88,16 +88,41 @@ function fmt(dateStr: string): string {
       <a class="btn btn-ghost" href="#product">What it does</a>
     </div>
 
-    <div class="hero-rail">
-      <span class="rail-label">lifecycle · phase rail</span>
-      <PhaseRail active={1} variant="labeled" />
+  </section>
+
+  {/* ============ THE METHOD ============ */}
+  <section id="method" class="site-container">
+    <div class="section-head">
+      <span class="idx">[ 01 ]</span>
+      <h2>The Method</h2>
+      <span class="meta">design · tooling · output</span>
+    </div>
+
+    <div class="method-flow">
+      <div class="stage">
+        <span class="stage-ord">01</span>
+        <h3 class="stage-name">Front-load design</h3>
+        <p class="stage-gloss">Spend the effort before any code moves. Exhaustive design up front is what makes everything downstream hands-off.</p>
+      </div>
+      <span class="stage-arrow" aria-hidden="true">→</span>
+      <div class="stage">
+        <span class="stage-ord">02</span>
+        <h3 class="stage-name">Invest in tooling</h3>
+        <p class="stage-gloss">Adopt the best machinery there is — Spec Kit, the agent CLIs, the multi-agent audit — instead of hand-rolling it.</p>
+      </div>
+      <span class="stage-arrow" aria-hidden="true">→</span>
+      <div class="stage">
+        <span class="stage-ord">03</span>
+        <h3 class="stage-name">Industrialize production</h3>
+        <p class="stage-gloss">Then step back and let the line run: automated, audited, regular — never riding on how much attention you can spare.</p>
+      </div>
     </div>
   </section>
 
   {/* ============ PRODUCT ============ */}
   <section id="product" class="site-container">
     <div class="section-head">
-      <span class="idx">[ 01 ]</span>
+      <span class="idx">[ 02 ]</span>
       <h2>The Lifecycle</h2>
       <span class="meta">4 phases · one loop</span>
     </div>
@@ -113,19 +138,18 @@ function fmt(dateStr: string): string {
         </article>
       ))}
     </div>
-  </section>
 
-  {/* divider rail echo */}
-  <div class="site-container">
-    <div class="divider-rail">
-      <PhaseRail active={3} variant="divider" />
+    {/* full lifecycle rail — the loop visualized, beneath the pipeline cards */}
+    <div class="lifecycle-rail">
+      <span class="rail-label">lifecycle · phase rail</span>
+      <PhaseRail active={1} variant="labeled" />
     </div>
-  </div>
+  </section>
 
   {/* ============ WHAT / WHY / HOW ============ */}
   <section id="how" class="site-container">
     <div class="section-head">
-      <span class="idx">[ 02 ]</span>
+      <span class="idx">[ 03 ]</span>
       <h2>What / Why / How</h2>
       <span class="meta">orientation</span>
     </div>
@@ -151,7 +175,7 @@ function fmt(dateStr: string): string {
   {/* ============ DEVLOG ============ */}
   <section id="devlog" class="site-container">
     <div class="section-head">
-      <span class="idx">[ 03 ]</span>
+      <span class="idx">[ 04 ]</span>
       <h2>Devlog</h2>
       <span class="meta">building in the open</span>
     </div>
@@ -231,8 +255,8 @@ function fmt(dateStr: string): string {
     margin-top: 2.125rem;
   }
 
-  .hero-rail {
-    margin-top: clamp(3rem, 7vw, 5.25rem);
+  .lifecycle-rail {
+    margin: clamp(2.5rem, 5vw, 3.5rem) 0 0;
     padding: 1.625rem clamp(0.5rem, 3vw, 2.5rem) 1.375rem;
     border: 1px solid hsl(var(--border));
     border-radius: var(--radius);
@@ -290,12 +314,98 @@ function fmt(dateStr: string): string {
     color: hsl(var(--muted-foreground));
   }
 
-  .divider-rail {
-    margin-block: clamp(0.5rem, 3vw, 1.75rem);
-    padding: 1.375rem clamp(0.5rem, 3vw, 2.5rem);
-    border-top: 1px solid hsl(var(--border));
-    border-bottom: 1px solid hsl(var(--border));
-    background: hsl(var(--card) / 0.3);
+  /* ---- The Method (three-stage flow) ---- */
+  .method-flow {
+    display: flex;
+    align-items: flex-start;
+    gap: clamp(1.25rem, 3vw, 2.75rem);
+  }
+
+  .stage {
+    flex: 1;
+  }
+
+  /* VFD / oscilloscope-phosphor readout "tube" */
+  .stage-ord {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 2.4em;
+    padding: 0.24em 0.52em;
+    border-radius: 4px;
+    font-family: var(--font-mono);
+    font-weight: 700;
+    font-size: clamp(2rem, 4vw, 3rem);
+    line-height: 1;
+    color: hsl(var(--primary));
+    text-shadow:
+      0 0 6px hsl(var(--primary) / 0.9),
+      0 0 16px hsl(var(--primary) / 0.55),
+      0 0 30px hsl(var(--primary) / 0.35);
+    background: radial-gradient(ellipse at 50% 42%, hsl(var(--primary) / 0.14), hsl(200 45% 4%) 72%);
+    box-shadow:
+      inset 0 0 16px hsl(var(--primary) / 0.16),
+      inset 0 0 0 1px hsl(var(--primary) / 0.22),
+      0 0 26px -8px hsl(var(--primary) / 0.45);
+    position: relative;
+    overflow: hidden;
+    transition: text-shadow 0.25s ease, box-shadow 0.25s ease;
+  }
+
+  .stage-ord::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: repeating-linear-gradient(
+      to bottom,
+      transparent 0 2px,
+      hsl(0 0% 0% / 0.22) 2px 3px
+    );
+    mix-blend-mode: multiply;
+    pointer-events: none;
+  }
+
+  .stage:hover .stage-ord {
+    text-shadow:
+      0 0 8px hsl(var(--primary)),
+      0 0 22px hsl(var(--primary) / 0.7),
+      0 0 42px hsl(var(--primary) / 0.45);
+    box-shadow:
+      inset 0 0 22px hsl(var(--primary) / 0.26),
+      inset 0 0 0 1px hsl(var(--primary) / 0.4),
+      0 0 38px -6px hsl(var(--primary) / 0.6);
+  }
+
+  .stage-name {
+    font-family: var(--font-display-tight);
+    font-weight: 800;
+    font-size: clamp(1.2rem, 2.2vw, 1.6rem);
+    letter-spacing: -0.01em;
+    text-transform: uppercase;
+    color: hsl(var(--foreground));
+    margin: 1rem 0 0.6rem;
+  }
+
+  .stage-gloss {
+    margin: 0;
+    font-size: 0.9375rem;
+    line-height: 1.55;
+    color: hsl(var(--muted-foreground));
+  }
+
+  .stage-arrow {
+    flex: 0 0 auto;
+    margin-top: 1.05rem;
+    font-family: var(--font-display-tight);
+    font-size: clamp(1.5rem, 2.5vw, 2.1rem);
+    line-height: 1;
+    color: hsl(var(--primary));
+    text-shadow: 0 0 14px hsl(var(--primary) / 0.5);
+  }
+
+  @media (max-width: 760px) {
+    .method-flow { flex-direction: column; gap: 1.5rem; }
+    .stage-arrow { margin: 0 0 0 0.5rem; transform: rotate(90deg); transform-origin: left center; }
   }
 
   /* ---- Product phase grid ---- */


### PR DESCRIPTION
## stackcontrol.org — homepage design pass + copy refinements

A `/frontend-design` pass on the homepage, plus messaging tweaks. Merging lands
it on `main` → live on stackcontrol.org.

### Design / layout
- **THE METHOD** is now its own section `[ 01 ]` (before THE LIFECYCLE): the
  three-move thesis — **front-load design → invest in tooling → industrialize
  production** — as a three-stage assembly-line flow with glowing cyan **VFD /
  oscilloscope-phosphor ordinal "tubes"** (bloom, inner glow, bezel, scanlines;
  surge on hover) joined by cyan flow arrows. Lifecycle / What-Why-How / Devlog
  renumbered `[ 02 ]`–`[ 04 ]`.
- The full labeled **phase rail** now sits beneath the lifecycle cards (the
  anemic "divider" orphan is gone); the hero leads with the babysitter hook alone.
- **Header:** added a `Method` jump-nav item; on small screens the nav wraps to
  its own full-width line (clean two-line header) instead of overflowing.

### Copy
- "a Claude Code plugin" → **"an agent plugin"** (Claude is the start, not the limit).
- "industrial line" → **"assembly line"** (consistent with the tagline).
- "audit barrage" → **"multi-agent audit"** on the homepage (the origin-story
  article keeps the coined term it explains).
- hero lede: "cut corners" → **"shove beans up their nose"**.

### Docs
- `DESIGN-SYSTEM.md` §5/§6/§7 updated (VFD-readout + Method-flow motifs, nav +
  rail placement, assembly-line / The Method vocabulary); `messaging-copy-deck.md`
  updated to match.

Verified: stackcontrol prod build green.
