### PR TITLE
stackcontrol.org — reword the What/Why/How 'Why' heading

### DIFF
--- a/docs/1.0/001-IN-PROGRESS/stackcontrol-site/messaging-copy-deck.md
+++ b/docs/1.0/001-IN-PROGRESS/stackcontrol-site/messaging-copy-deck.md
@@ -72,7 +72,7 @@ Four cards in the existing `NN / NAME` + blurb idiom:
 - **WHAT — "An assembly line for change":** stack-control wraps every change in a disciplined line
   — define once, then implement and audit on a loop until the diff is clean — instead of letting an
   agent freestyle from prompt to merge.
-- **WHY — "Brilliant, and not to be trusted":** Left unsupervised, agents drift: they skip scope,
+- **WHY — "Agents cause brilliant chaos":** Left unsupervised, agents drift: they skip scope,
   over-build, confabulate, and ship work no one checked. The line is the adult supervision — gates
   between intent and merge.
 - **HOW — "Best practices, not bespoke":** Underneath, it's the state of the art — a Spec Kit spec

--- a/src/sites/stackcontrol/pages/index.astro
+++ b/src/sites/stackcontrol/pages/index.astro
@@ -161,7 +161,7 @@ function fmt(dateStr: string): string {
       </div>
       <div class="col">
         <span class="tag">WHY</span>
-        <h3>Brilliant, and not to be trusted</h3>
+        <h3>Agents cause brilliant chaos</h3>
         <p>Left unsupervised, agents drift: they skip scope, over-build, confabulate, and ship work no one checked. The line is the adult supervision — gates between intent and merge.</p>
       </div>
       <div class="col">


### PR DESCRIPTION
Tightens the WHY column heading: "Brilliant, and not to be trusted" dangled onto stack-control; → **"Agents cause brilliant chaos"** so the agents are the unambiguous subject. Homepage copy + copy-deck record. Single-commit, build green.