### PR TITLE
stackcontrol.org — generalize 'for Claude Code' to 'for coding agents'

### DIFF
--- a/src/sites/stackcontrol/content/blog/standing-up-a-site-with-its-own-lifecycle/index.md
+++ b/src/sites/stackcontrol/content/blog/standing-up-a-site-with-its-own-lifecycle/index.md
@@ -9,7 +9,7 @@ phase: "PIPELINE"
 draft: false
 ---
 
-This site is the public home of **stack-control**, a lifecycle plugin for Claude Code. It is also the
+This site is the public home of **stack-control**, a lifecycle plugin for coding agents. It is also the
 first thing built end-to-end by that plugin in front of an audience. The whole point of stack-control
 is that "make this change" should become a tracked loop rather than an unsupervised sprint, so it
 seemed dishonest to launch the product page any other way. We ran the loop on the loop.


### PR DESCRIPTION
Generalizes the standing-up devlog post's opening — stack-control is "a lifecycle plugin for coding agents" (was "for Claude Code") — to match the homepage's agent-agnostic framing. The factual Claude references in the origin story (the CLAUDE.md file, the Claude×Codex MESA II collab, the Claude·Codex·Gemini audit) are left intact as accurate history. Single-commit, build green.