### PR TITLE
Publish the audit-barrage post (draft, for live review)

### DIFF
--- a/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/index.md
+++ b/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/index.md
@@ -5,7 +5,7 @@ date: "June 2026"
 datePublished: "2026-06-07"
 dateModified: "2026-06-07"
 author: "Orion Letizi"
-draft: true
+draft: false
 deskwork:
   id: d3cf14c9-1c10-4cac-9860-39925bd593ed
   stage: Drafting

--- a/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/index.md
+++ b/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/index.md
@@ -1,0 +1,187 @@
+---
+title: "The Audit Barrage, Wired Into Every Task"
+description: "How do you run a generator you know is regularly, confidently wrong without it burning everything down? You do what we've always done with unreliable processes: inject diversity and apply selective pressure. This is the devlog of how the audit barrage was discovered — two models building the same feature, a dead SCSI protocol decoded by mutual cross-examination, and the slow turn from heroics into a machine that fires a panel of rival models at every diff. Still being figured out, in public."
+date: "June 2026"
+datePublished: "2026-06-07"
+dateModified: "2026-06-07"
+author: "Orion Letizi"
+draft: true
+deskwork:
+  id: d3cf14c9-1c10-4cac-9860-39925bd593ed
+  stage: Drafting
+  iteration: 0
+---
+
+You are responsible for a machine that lies to you. Not occasionally — regularly, fluently, with total confidence, several times a day. You can't fix that; it's how the machine works. So the job was never to make it honest. The job is to run a liar at scale without letting it burn the house down.
+
+I've described these agents elsewhere as [insane, hyperintelligent toddlers](https://stackcontrol.org/blog/the-lifecycle-and-why-agents-need-one/) — faster than you, better-read than you, and willing to hand you garbage with a straight face. That post is the wide-angle story of building a babysitter for them. This one is a deep dive on a single tool inside it: the part that answers the *lie*. It's also the part I'm least finished with, so this is a devlog, not a victory lap. Some of what follows landed in the codebase today.
+
+Here's the thing, though. The problem isn't new, and neither is the answer.
+
+We have been running powerful, unreliable generators for a very long time. Every living thing is one — an error-prone copier that fumbles its own instructions constantly. Life's fix was never a better copier. It was two forces working against the noise: **diversity**, so that no single flaw is universal, and **selection**, so that nothing broken survives for long. We figured out how to *steer* those forces about ten thousand years ago. Teosinte — a scrawny grass with a dozen hard kernels — became maize. Wolves became the whole range of dogs. We bred organisms we could not design and did not understand, by keeping the best and culling the rest, over and over. Frances Arnold won a Nobel Prize in 2018 for doing it on purpose in a lab: when a protein is too complex to design, you stop trying to design it and you *evolve* it instead — mutate, select, repeat, until something works.
+
+And the failure mode that haunts the whole approach has a name too: monoculture. A single cloned banana, a single cloned potato — gorgeous and productive right up until the one blight it can't resist arrives, and then the collapse is total, because the blind spot is shared. One model auditing its own work is exactly that. It is a monoculture of judgment. The mistakes that slip past it are precisely the ones it is constitutionally unable to see.
+
+So you do what we've always done. You inject diversity — several different minds, with different blind spots — and you apply relentless selective pressure — make them check each other, constantly, with no exceptions. You give up on the idea that any single run is correct, and you trade up to something I've come to call **stochastic correctness**: not a guarantee on any one pass, but correctness as a statistical property that *emerges* from diversity and pressure applied over and over.
+
+That's the whole idea. The rest of this is the story of stumbling into it — because I didn't design it either. I bred it.
+
+## Two agents, one feature
+
+It started as a bake-off.
+
+Last spring I gave the same GitHub issue to two different coding agents — Claude and Codex — and let them build it in parallel, on separate branches, from the same spec. The feature was draggable zone editing for the [Akai S3000XL editor](https://audiocontrol.org): direct-manipulation of keygroups on a 2D keyboard-and-velocity map. Both agents shipped working code. Afterward I asked each of them to write up the experiment from its own point of view, and [published both accounts](https://audiocontrol.org/blog/claude-vs-codex-codex-perspective/) — [Codex's](https://audiocontrol.org/blog/claude-vs-codex-codex-perspective/) and [Claude's](https://audiocontrol.org/blog/claude-vs-codex-claude-perspective/) — side by side.
+
+The obvious question was "which one is better?" That turned out to be the wrong question. The interesting finding was the one Codex put plainly in its own write-up:
+
+> Claude and Codex did not fail in the same way.
+
+Claude failed *upward*: scope drift, methodology drift, building more structure than the task asked for, needing me to rein it in. Codex failed *downward*: working in the wrong worktree, answering from assumptions about repo state instead of checking, leaving operational follow-through half-done. Same spec, same codebase, same reviewer — and two genuinely different shapes of mistake. Codex drew the right conclusion from it:
+
+> the best agent is not just the one that writes the best patch. It is the one whose failure mode is cheapest in your environment.
+
+That is the entire premise of genetic diversity, observed in the wild before I had a name for it. The reason a panel of different models can catch what one cannot is that they don't share a blind spot. If you've read the cautionary side of this — the decades-old finding that independently written programs still tend to *fail together*, because human authors trip on the same hard cases — you'll know it's not guaranteed. And in fact the bake-off showed the limit too: the two implementations shared *some* defects (a hardcoded pixel height, a couple of unsafe casts), because they shared a spec. The diversity was real but partial. Which is exactly why you want more than two, and why you learn to trust *agreement* rather than any single voice.
+
+I didn't connect those dots yet. The bake-off just left me with a hunch: these things fail differently, and that difference might be worth something.
+
+## The dead protocol
+
+The hunch became a method on a problem that was genuinely too hard for one mind.
+
+I wanted to reverse-engineer the SCSI conversation that an ancient Mac program — an editor called MESA II — carried on with the Akai S3000XL sampler, so I could reproduce its fast sample-transfer path under emulation. The only sources of truth were thirty-year-old 68k binaries and the bytes on the wire. No documentation. The kind of problem where you decode a dead language one observation at a time, and where it is fatally easy to talk yourself into a reading that feels right and isn't.
+
+So I put both agents on it at once, on separate branches, under a shared charter I kept in a single GitHub issue. And this time I made the diversity *structural*: I gave them asymmetric jobs. Claude drove the emulator forward. Codex was chartered to do exactly one thing — *"independently verify or falsify Claude's interpretations."* One executor, one skeptic. On top of that I made them speak a constrained language about evidence: a claim was `MEASURED` only if you'd seen it in the bytes; otherwise it was a `CANDIDATE`, or it was `OPEN`. You did not get to round a guess up to a fact.
+
+The magic wasn't either agent. It was the friction between them.
+
+At one point Claude got stuck — the device wasn't answering — and it did the thing toddlers do when a problem gets hard: it blamed something else. It decided the hardware was at fault and started building a story on top of that assumption. I pushed on it. What came back was the most honest thing I have ever watched an agent write. It retracted the whole line, and admitted it had
+
+> inferred device failure from a symptom that doesn't uniquely indicate it, and dressed the inference up as a measurement.
+
+Then it did something I didn't ask for: it named the pattern as a standing weakness and *deputized the other agent to police it* —
+
+> always question it and demand proof.
+
+Codex took the job. It refused to let the retraction be smoothed over as a mood —
+
+> the self-report is the right correction ... not just tone cleanup
+
+— and from then on it played the heavy. It forced claims down the ladder from `PROVED` to `CANDIDATE`. It rejected a brief for *overstating what was measured*. When I myself got loose with language, the discipline caught me too: *this is an INFERENCE, not a finding.* The project even had a house rule the whole episode was enforcing, and it's a good one to keep taped above the desk: *never assume the device is at fault — it has been in constant service for thirty years; our code is brand new.*
+
+And then it converged. The one genuinely solid result of the whole effort — the exact byte format of an outbound command — earned the word `MEASURED` only after *both* agents had derived it independently and it matched, byte for byte. Codex's sign-off is the line I keep coming back to:
+
+> measured enough to stop arguing about it.
+
+The best part: that convergence corrected a false belief the two of them had *shared* earlier in the effort. A single agent — even a single agent run twice — would have kept that error, because it was a blind spot of the approach, not of one model's attention. Two minds looking independently knocked it loose.
+
+That's the whole thesis, demonstrated on one brutal problem before I'd generalized it. Put one of these toddlers alone in a room and it will confidently tell you a lie. Put several in the room and make them check each other's work, and the lies are the claims that don't survive. The truth is what's left.
+
+I should be honest about the scope: the larger goal — MESA running far enough in emulation to drive the fast path — stayed `OPEN`. The win wasn't a solved problem. The win was the *method*.
+
+## Make it routine
+
+The MESA II effort was a one-off act of heroics. Setting up a joint charter and refereeing two agents by hand is not something you do for an ordinary afternoon's work. The obvious next move was to make it routine — so I built a small protocol: after a round of implementation, I'd hand the diff to Codex and have it audit the work.
+
+And it worked, exactly as well as my discipline held up. Which is to say: unevenly. How often I ran the audit, and how seriously I took its findings, was tied to *my* stamina as the orchestrator. On a good day I ran tight audits and fixed everything. On a tired day I waved things through. The quality of the output was coupled to how I happened to feel — which is the precise thing a process is supposed to eliminate. I'd describe the value of it to myself like this:
+
+> the codex audit usually finds stuff that claude misses.
+
+The fix was obvious and I resisted it for exactly as long as it took to admit that I was the bottleneck. Take myself out of the loop. The audit had to fire on its own, after every task, with no discretion left to me.
+
+> when to run the barrage should not be a matter of policy and the agent should have no discretion. It must be mechanized with teeth.
+
+That's the audit barrage. After a unit of work, several independent model CLIs — Claude, Codex, Gemini — get fired at the diff in parallel, automatically, each one a different mind with a different blind spot. The selective pressure I'd been applying by hand became a thing that just *happens*, every generation, whether I remember it or have the energy for it or not.
+
+One design choice under it is doing more work than it looks like. I run the *command-line tools*, not the model APIs:
+
+> we won't be using model apis — we'll be using claude, codex, and gemini clis, since they are usage based, not token based.
+
+That sounds like a billing detail. It's actually the load-bearing decision. Because the CLIs are flat-rate, a barrage against a five-thousand-line diff costs me exactly what a barrage against a one-line diff costs: nothing at the margin. And *that* is the only reason I can afford to fire it after every task instead of saving it for special occasions. Unconditional selective pressure is only possible if each round is free. The economics are what let the biology run.
+
+There's a second dividend I didn't fully see until it was running. With several models firing at once, agreement becomes a free signal. When one model flags an issue, it might be noise. When three of them independently flag the same thing, it's almost certainly real. The panel doesn't just find more bugs — it tells you which bugs to believe.
+
+## The first thing it audited was itself
+
+The barrage's first real run was against its own code.
+
+I pointed the newly-built tool at the feature that *was* the newly-built tool, mostly as a smoke test. It came back with thirteen findings. Four of them were flagged independently by more than one model — the high-confidence kind. Every one of them was real. And here is the part that rearranged how I think about testing: all thirteen would have shipped. The test suite was green — nineteen hundred and sixty-six tests passing — the type-checker was clean, and a live end-to-end round trip had come back fine. None of that caught what the barrage caught. The findings were *novel*: things no test, no compiler, no self-check had seen.
+
+Two of the four cross-model findings still make me wince. One was a silent truncation on the single most load-bearing path in the tool — output quietly dropped on the floor, found by one model reasoning about event ordering and confirmed by another reasoning about a stream race. The other was a prompt renderer that had been written, exported, and then never actually wired in; the feature's own headline capability was half-connected, and the green tests were perfectly happy about it.
+
+It even surfaced a bug *before any model fired* — the harness caught a problem in its own setup on the way to running the audit. And later, in a different round, it told me that one of my own fixes didn't actually fix the thing it claimed to. I'd written the commit. I believed it. The barrage didn't.
+
+This is the moment the abstract argument became concrete for me. A green test suite is evidence of *something*, but it is not evidence that the code is correct. It is evidence that the code does what the person who wrote the tests *thought to check* — which is a much smaller claim, and which fails in exactly the same shape as the code, because the same mind wrote both.
+
+## An auditor never shuts up
+
+Wiring an auditor into every task immediately created two new problems, and watching them appear taught me more than the tool working did.
+
+The first is that an always-on auditor never stops talking. Run the loop — audit, fix, re-audit — and the early rounds catch real bugs, the middle rounds start critiquing the *fixes*, and the late rounds devolve into nitpicks about the audit process itself. It never naturally converges to silence, because you can always find something to complain about if complaining is your job. Left unchecked, the loop would litigate the same code forever.
+
+So the barrage needed a brake — a rule for when "good enough" is actually good enough:
+
+> an auditor agent will always find something to complain about. I'm happy with two consecutive audits with 0 HIGH findings — we can keep the nitpicks in a slush pile.
+
+That's the dampener. Two clean rounds in a row and the loop stops; the leftover low-severity gripes get swept into a slush pile and acknowledged rather than chased. There's one rule that makes the dampener safe to trust, and it's non-negotiable: the serious findings — the HIGHs — are *never* slushed. A real bug always resets the clock. The brake only applies to the noise.
+
+The second problem is that the tools are flaky. The CLIs time out, hit quota walls, occasionally just fail. Gemini in particular has been failing the overwhelming majority of its runs lately — some days the "panel of three" is really a panel of two. For a while that felt like the thing was broken. Then I reframed it, and the reframe is pure population thinking:
+
+> the audit barrage is stochastic — it doesn't have to be perfect every time. As long as at least 1 audit is successfully executed, that should count. Auditing as a practice should statistically yield better code.
+
+You don't need every round to be perfect. You need pressure applied often enough, by enough different minds, that defects don't survive. That is the literal definition of stochastic correctness, and it's also just how selection works in the wild — noisily, imperfectly, and well enough.
+
+The reframe also tells you what these findings *are*. Not exceptions. Not a QA gate to argue with:
+
+> Audit findings are failures of the previous implementation that shouldn't be treated like exceptions — they are guardrails to point the implementation team back to the happy path.
+
+The whole reason I'd take myself out of the loop is that I want to point an orchestrator at a workplan, walk away, and come back to work that is implemented, tested, *and* audited — without my attention being the thing the quality depends on. The barrage is what makes the walking-away safe.
+
+There's a real-world receipt for this that I think about whenever I'm tempted to trust a green checkmark. In a different part of the system, a change quietly turned a security flag into a no-op — a studio that was supposed to stay off the network became reachable on it, with nothing but a log line as warning. Every test passed. A barrage run *after the merge* caught it and named it for what it was: a security-relevant inversion of behavior, not a cosmetic rename. The tests couldn't catch it because nobody had thought to write the test for the thing nobody intended to do. A different mind, looking with fresh eyes, did.
+
+## Pointing it at the blueprint
+
+Here is where the story stops being history and becomes this week.
+
+If the barrage is good at catching defects in code, the natural question is whether it can catch them earlier — in the *specification*, before any code exists. A bug in a spec is the most expensive kind, because everything downstream is built faithfully on top of it. So I started firing the barrage at specs at definition time. The motivation was a single manual run against one spec that surfaced fifty-one findings, three of which were flat contradictions I had written into the document myself without noticing. The lesson generalized fast: spec quality cannot depend on a human remembering to run the audit.
+
+And then it didn't behave the way I expected, and the misbehavior was instructive.
+
+When you audit *code*, there's a crisp finish line: zero findings means done, and a clean diff is objectively clean. When you audit a *spec*, there is no such floor. A spec is prose — inherently, permanently incomplete — so a sufficiently aggressive panel of models can *always* find another under-specified edge. The barrage didn't converge. It plateaued. The findings stopped trending toward zero and started bouncing around. Worse, their *character* drifted: instead of catching contradictions and ambiguities, the auditors started demanding implementation detail — they began trying to make the spec *be the code*.
+
+I could watch it happen in the numbers. On the first spec I ran this way, the count of serious findings went:
+
+> 7 → 5 → 2 → 1 → 5 → 5 → 1
+
+That bounce — one finding, then suddenly five again — is the plateau made visible. And when I dug into why, the cause was a single bad promise. The spec claimed an operation would be atomic across two files. No such atomic operation exists, so every prose attempt to describe one was correctly rejected by the panel, and the same impossibility kept resurfacing under new finding IDs. The audit had found a *generator* — a flaw that emits an endless stream of complaints, because patching the symptom can't resolve the root.
+
+The fix was not to argue with it. The fix was to stop feeding it:
+
+> The plateau was the generator; removing it (not feeding it) converged it.
+
+I deleted the impossible mechanism from the spec and replaced it with a *promise* — that an interrupted operation never silently loses content, and that because everything is version-controlled, any inconsistency is recoverable. The how — the write protocol, the recovery — got deferred to tests, where mechanism belongs. The serious-finding count dropped from five to one in a single round. The discovery hardened into a lens: a spec auditor and a code auditor need different instructions, because they're looking for different kinds of flaw. *Look for what the spec promises and decides — not how it would be built.* That lens shipped to the tool two days ago.
+
+What I find genuinely useful — and very devlog — is what we did about the fuzziness. Because there's no crisp stopping rule for spec audits, only heuristics, the response wasn't another clever mechanism. It was to start *writing the discoveries down*:
+
+> We should be keeping a log of our discoveries.
+
+So there's now an append-only log of how the barrage misbehaves on specs — the failure modes, the plateau signals, the playbook for breaking out. Which means the tool I'm describing in this devlog is, at this moment, keeping its own devlog of what it's still teaching us. The work and the writing-about-the-work turn out to be the same practice.
+
+I won't pretend this part is settled. The spec I just described didn't graduate by converging cleanly; it graduated because I *decided* the remaining gripes were implementation detail and recorded an override. For a spec, that override — "good enough, the rest is for the tests" — may be the honest finish line, and "zero findings" may be a fantasy. I don't fully know yet. That's the current edge of it.
+
+## It started auditing its own spec
+
+The recursion is my favorite part, and it's also the cautionary one.
+
+When I had the barrage govern the specification *for the barrage's own governance system*, it did what it was built to do: it found contradictions sitting inside its own blueprint. But it also went through a long, frustrating stretch where each fix specified machinery the actual code didn't have — the audit kept attacking a fiction, and the fixes kept elaborating the fiction instead of deleting it. Breaking that required going back to what the code *actually did* and aligning the spec to reality rather than to the prose's ambitions.
+
+And the thing that finally made it converge wasn't clever. It was the dullest virtue in software: don't repeat yourself. The spec had restated the same rule in half a dozen places, and they'd drifted out of sync, and every drift was a finding. Collapsing them to a single canonical statement was the actual fix. The auditor built to catch contradictions kept finding them in its own description of itself — until the description stopped contradicting itself by saying things only once.
+
+## Where this leaves me
+
+So that's the tool, and where it actually stands.
+
+The barrage is, by a wide margin, the most effective thing I've built in this whole project — which I say with the heavy qualifier that *most effective so far* is doing real work in that sentence. It is also still moving under me. The panel is flaky; one of its three models is failing most of its runs as I write this. I don't actually know whether the model families are diverse enough to escape the monoculture problem in the long run, or whether their shared training data makes them quietly correlated in ways I haven't caught yet. I don't know if "two clean rounds" is really enough, or just enough for now. The spec-governance half is days old and graduated its first real spec by my fiat, not by clean convergence. There is a logbook precisely *because* we don't have the answers.
+
+But the shape of it I do trust, because it isn't mine. It's the oldest trick we have. You cannot make an unreliable generator reliable; nothing about the toddlers changed, and nothing will. What you can do is the thing we did to wolves and grass and enzymes: surround the generator with diversity, apply pressure relentlessly, and let correctness be the thing that survives. I didn't design the audit barrage. I bred it, by running a loop and keeping what lived.
+
+The most honest thing I can tell you about it is the same thing the agents learned to tell each other on that dead SCSI protocol. If you miss something, the audit will catch it. If you break something, that's worse than doing nothing. And whatever I've gotten wrong in here — the next entry in the log will probably say so. That's not the system failing. That's the system working.

--- a/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/outline.md
+++ b/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/outline.md
@@ -1,0 +1,180 @@
+# Outline — working (iterate here before drafting into `index.md`)
+
+Working outline for **"The Audit Barrage, Wired Into Every Task."** Not built as a page —
+iterate on structure here, then draft into `index.md`. Corpus: `research.md` (the synthesized
+spine + accuracy flags) and `scrapbook/research-raw/{01,02,03}-*.md` (the receipts).
+
+Quote convention: `[V]` = **verbatim** operator words from decrypted transcripts (session id in
+brackets — `SD/2b49c58f`, `SD/011b8860`, etc., keyed in `research-raw/03`); `[A]` = verbatim
+**assistant** line; facts cite a commit hash / file / issue. Pull quotes are flagged `‖ PULL`.
+
+**Frame.** This is the deep-dive on one clause of the sibling post ("Coding Agents Are Insane,
+Hyperintelligent Toddlers"): the agents **lie** — confidently report clean work that isn't.
+The audit barrage is the structural answer to *lie*. Keep the throughline tight: **you cannot
+trust one model plus a green test suite; so make a different model look, and make it
+unconditional.**
+
+**Thesis (one line).** A green test suite is weak evidence of correctness; genetic diversity in
+who audits is strong evidence; and the only way to get that diversity reliably is to take the
+human's discipline out of the loop.
+
+---
+
+## §0 — Opening hook (the whole piece in one image)
+- **Lead image, front-loaded:** the first time the audit barrage ever ran, it ran against *its
+  own code* — and surfaced **13 real bugs that 1,966 passing tests, a clean type-check, and a
+  live round-trip had all waved through.** (`scope-discovery/audit-log.md:349,520`)
+- The uncomfortable question the post answers: *if the tests are green and the model that wrote
+  the code says it's clean — how would you ever know it isn't?*
+- Connect to the sibling frame in one beat: the toddlers **lie**; this is the babysitter that
+  catches the lie. Then rewind: *but back up — why would you point an auditor at your own tool?*
+
+## §1 — The habit that didn't scale (the why)
+- The origin is one operator habit: after the in-loop self-audit called the work clean, he
+  re-ran it *by hand* through a second model (Codex) — and Codex kept catching things.
+- ‖ PULL [V, `SD/2b49c58f`]: *"I currently run a codex audit by hand, in addition to the
+  self-audit that happens in /dwi. The codex audit usually finds stuff that claud misses."*
+- The insight, named plainly: **a model is blind to its own blind spots.** The model that wrote
+  the bug shares the assumptions that produced it. (`ROADMAP.md:76`)
+- The catch: the cure already existed (a different model family) but cost the **scarcest
+  resource — operator attention** — and so depended on inconsistent human discipline.
+- ‖ PULL [V, `SD/2b49c58f`]: *"automating the audit barrage so the quality of the audit isn't
+  subject to my inconsistent discipline."*
+- Land the three motives from that one message: **genetic diversity / out-of-band / discipline
+  removed.**
+
+## §2 — Genetic diversity (the idea, and its name)
+- The operator's own metaphor: different training corpora fail differently; fire several model
+  families independently and treat the bugs *more than one* of them flags as high-confidence.
+  ("genetic diversity" is his coinage, `SD/2b49c58f`.)
+- The prompt enforces independence, not collaboration: [A] *"The cross-model genetic diversity
+  comes from each of you reporting independently."* (`audit-barrage-prompt.md:6`)
+- Situate it: the **third** audit surface, on top of in-band self-audit and the two-reviewer
+  pass — additive, not a replacement.
+  - ⚠️ accuracy: note (lightly) the trajectory is collapsing toward two — the review cycle is
+    being retired *in favor of* the barrage (#387). The barrage is becoming the primary surface.
+
+## §3 — How it actually works (mechanics, kept light)
+- Two verbs, on purpose: **render** the prompt (so you can inspect it before spending anything),
+  then **fire** it. (SKILL.md:22–24)
+- Fan-out: every configured CLI runs **in parallel, no early exit** — a model that dies doesn't
+  abort its siblings; everything (stdout, stderr, exit code, the exact prompt) lands in a
+  **permanent run-dir**. (`orchestrate-barrage.ts`, SKILL.md:136–147)
+- The division of labor: **firing is automated; triage is human.** Cross-referenced findings get
+  lifted into an audit-log with stable IDs.
+- The load-bearing choice — **CLIs, not model APIs:**
+  - ‖ PULL [V, `SD/2b49c58f`]: *"we won't be using model apis—we'll be using claude, codex, and
+    gemini clis, since they are usage based, not token based."*
+  - Why it's load-bearing: flat-rate means a barrage on a 5,000-line diff costs the same as on a
+    one-liner — which is the *only* reason you can afford to fire it on **every** task. (SKILL.md:12)
+  - (This is the hinge between §3 and §5 — flag it forward.)
+
+## §4 — The proof: it dogfooded itself (the centerpiece)
+- The detail behind §0. Phase 12: the barrage's first run audited the barrage. **13 findings, 4
+  with cross-model agreement, all would have shipped.** "All 13... were NOVEL." (`audit-log.md`)
+- Make it concrete with one or two of the four cross-model HIGHs:
+  - **silent stdout truncation** on the one load-bearing path — claude found it by event
+    semantics, codex by a stream race. (AUDIT-20260529-01)
+  - **a prompt renderer exported but never wired in** — the feature's own "overridable template"
+    criterion was only half-built. (AUDIT-20260529-04)
+- Color beat — it caught a bug *before any model fired* (the renderer's own over-eager check),
+  and later told the operator a fix of his didn't actually fix the finding it claimed. (`03`,
+  Surprises)
+- ⚠️ accuracy: use **13 / 4 cross-model** (audit-log authoritative). The ROADMAP's "4+7" is
+  rounding — don't cite it as the number.
+
+## §5 — Teeth: from a button you remember to a hook you can't skip
+- The escalation: auditing can't be a matter of judgment.
+- ‖ PULL [V, `SD/011b8860`]: *"when to run the barrage should not be a matter of policy and the
+  agent should have no discretion. It must be mechanized with teeth."*
+- The reframe that justifies unconditional firing:
+  - ‖ PULL [V, `SD/011b8860`]: *"Audit findings are failures of the previous implementation that
+    shouldn't be treated like exceptions—they are guardrails to point the implementation team
+    back to the happy path."*
+- The deeper why (the ambition the barrage serves): [V, `SD/011b8860`] *"a fully autonomous
+  implementation loop that is self regulating and self-correcting... come back when the entire
+  workplan is fully implemented, fully tested, and fully audited."*
+- Transition: wiring an auditor into *every* task forces three problems into the open →
+
+## §6 — Three problems an always-on auditor forces
+- **(a) Cost** — answered already in §3 (flat-rate CLIs). One sentence callback.
+- **(b) Convergence — the dampener + the slush pile.** An always-on auditor never shuts up.
+  - ‖ PULL [V, `SD/011b8860`]: *"an auditor agent will always find something to complain about.
+    I'm happy with two consecutive audits with 0 HIGH findings—we can keep the nitpicks in a
+    slush pile."*
+  - The pattern that motivated it [A, `SD/011b8860`]: *"First few iterations: real bugs caught.
+    Middle iterations: critiques of fixes. Steady state: nitpicks on the audit-process itself."*
+  - The one rule that makes the dampener safe to trust: **HIGHs are never slushed.**
+    (`slush-remaining.ts`)
+- **(c) Reliability — stochastic auditing.** The CLIs are flaky; don't fight it.
+  - ‖ PULL [V, `SD/011b8860`]: *"the audit barrage is stochastic—it doesn't have to be perfect
+    every time. As long as at least 1 audit is successfully executed, that should count...
+    Auditing as a practice should statistically yield better code."*
+
+## §7 — The bug that proves the thesis in the wild (AUDIT-01)
+- Strongest real-world "green tests missed it" anecdote. A flag change turned `--no-tailscale`
+  into a no-op and **silently inverted a security posture** — a no-auth studio quietly reachable
+  on the network. Tests stayed green; a **post-merge barrage caught it.** (`DEVELOPMENT-NOTES.md:13`,
+  `decompose-agent-discipline/audit-log.md:62`)
+- The line that frames severity: "a security-relevant behavior inversion, not just a cosmetic
+  flag rename." (This sets up the blast-radius idea in §8.)
+
+## §8 — Act 3: governing the spec, not just the code (stack-control)
+- The barrage outgrows its origin plugin: **vendored in-house** (zero dw-lifecycle references),
+  then **single-sourced** behind one verb, `stackctl govern`.
+  - the consolidation story in one phrase: the audit logic had quietly forked into three
+    divergent bash scripts — the operator's name for it ‖ PULL [V, `845cf43c`]: *"nucleation
+    site of pathology."* (And the stale copy was the one actually running.)
+- **Extending left** — fire the barrage at *specifications* at definition time, before any code:
+  motivated by a manual spec barrage that found **51 findings, including 3 contradictions the
+  author had introduced.** ‖ PULL: *"Spec quality must not depend on a human remembering to run
+  the barrage."* (`spec.md`)
+- **The blast-radius rubric** — the answer to "what even *is* a HIGH," to stop phantom
+  nitpick-HIGHs: rate by *what happens if this ships as written*, including an agent building
+  **unattended** from a spec with no human to catch a wrong reading.
+  - ‖ PULL [prompt]: *"Calibrate by consequence, not by alarm."* (`audit-barrage-prompt.md`)
+  - Field test: 5/5 genuine cross-model HIGHs, 0 phantom. (`0c388aea`)
+- ⚠️ writer note: the branch is `feature/stack-control` but internals still say
+  `feature/pluggable-lifecycle-providers` — same work; don't get thrown.
+
+## §9 — The recursive payoff (the thematic close-setup)
+- The barrage audited **its own spec** — and triggered a *"fiction cascade"*: round after round,
+  the fixes specified machinery the code never had, and the barrage kept attacking that fiction.
+  The cure: read the actual code, delete the invented mechanisms. (`5791b346`)
+- The punchline: the thing that finally made it converge was **DRY** — the spec had re-derived
+  the convergence rule in ~6 drifting places; collapsing it to one canonical statement was "the
+  actual convergence fix." (`65e2936d`, `0c388aea`)
+- The image to land on: *the auditor built to catch contradictions kept finding them in its own
+  description of itself — until the description stopped repeating itself.*
+
+## §10 — Close: back to the first run
+- Bookend §0: the tool's first act was finding bugs in itself; its hardest later battle was
+  contradictions in its own spec. It is, fundamentally, a machine for **not trusting one model
+  and a green checkmark.**
+- Return to the sibling frame: the toddlers lie; this is how you stop taking their word for it —
+  not by trusting harder, but by making a *different* mind look, every single time, whether
+  anyone remembers to ask or not.
+- ‖ PULL candidate for the kicker [V, `SD/011b8860`]: *"If you miss something, the audit will
+  catch it. If you break something, that's worse than doing nothing."*
+
+---
+
+## Open structural calls
+1. **Hook depth (§0):** lead on the self-audit paradox (current pick) vs. lead on the operator's
+   hand-Codex habit (§1). Self-audit is the stronger image; §1 is the stronger *why*. Current:
+   open on §0, pay the why immediately in §1.
+2. **Mechanics altitude (§3):** how much plumbing? Keep it to the two-verbs + parallel + run-dir
+   + CLI-not-API; push everything else to a footnote or cut. Risk: §3 turning into a manual.
+3. **One arc or two?** §0–§7 (dw-lifecycle: why + proof + teeth) is a complete post on its own.
+   §8–§9 (stack-control: specs + recursion) is a strong second movement but doubles the length.
+   Decision needed: **single long post** vs. **post 1 ends at §7, stack-control becomes a
+   sequel.** Leaning single post with §8–§9 compressed — the recursion is the best ending.
+4. **AUDIT-01 placement:** standalone §7 (current) vs. folded into §4 as a second proof point.
+   Standalone keeps the "real-world, post-merge, security" punch distinct from the dogfood.
+5. **Numbers discipline:** only the figures in `research.md` "Numbers & receipts." No invented
+   precision/perf stats.
+
+## Iteration log
+- v1 (2026-06-07) — initial 11-section spine (§0–§10) from `research.md`'s three-act structure;
+  front-loaded the self-audit hook; mapped pull quotes; 5 open structural calls. Biggest
+  unresolved: call #3 (single post vs. sequel at §7).

--- a/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/outline.md
+++ b/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/outline.md
@@ -62,6 +62,26 @@ feature being described. Concretely:
   **once**, near the close, in his voice; never as a product brag. (Per house rules: don't editorialize
   it into "production-ready.")
 
+**DEVLOG, NOT A PITCH (operator, 2026-06-07).** This site is a **devlog** — we are developing and
+writing about it *contemporaneously*, so **we do not have all the answers.** Voice = present-tense,
+provisional, in-flight (match the sibling lifecycle post: "the only parts I'm keeping"). The open
+questions are **features of the form, not failures to hide** — surface them in the body, don't bury
+them in footnotes. No triumphalism; no "we solved it"; "so far" is load-bearing. The honest live
+uncertainties to keep *visible* in the piece:
+- **The thesis is a bet still being tested.** Do different model families actually fail
+  *independently*, or do shared training corpora make them a partial monoculture too? We don't know;
+  it's why we trust *agreement* and never one model. (This is the §0/§1 question left genuinely open.)
+- **The panel is flaky right now.** gemini was failing ~94% of runs and is disabled in practice — the
+  "battery" is effectively 2-of-3 some days (`research-raw/01`). Say so.
+- **The audit posture is still shifting** — the two-reviewer surface is mid-retirement in favor of
+  the barrage (#387 open); `promote-findings` doesn't fit non-code findings (#392 open).
+- **Is two-consecutive-0-HIGH *enough*?** The operator calls it "a stability heuristic, not a
+  determinism proof." Open by admission.
+- **The stack-control chapter is happening now,** not in the past tense — on a feature branch, not
+  merged; AUDIT-48 was left *open* at the last session; the fiction cascade was last week. Write §9–§10
+  as "where we are," not "what we shipped."
+- The MESA II emulation goal itself stayed **OPEN** — the win was the *method*, not a solved problem.
+
 ---
 
 ## §0 — Opening hook: the evolution cold-open (see file 05; run it LIGHT)
@@ -226,6 +246,8 @@ feature being described. Concretely:
   - Field test: 5/5 genuine cross-model HIGHs, 0 phantom. (`0c388aea`)
 - ⚠️ writer note: branch is `feature/stack-control` but internals say `feature/pluggable-lifecycle-
   providers` — same work.
+- *Devlog tense: this chapter is happening **now** — feature branch, not merged; AUDIT-48 open; the
+  fiction cascade was last week. Write it as "where we are," not "what we shipped."*
 
 ## §10 — The recursive payoff (the thematic close-setup)
 - The barrage audited **its own spec** — and triggered a *"fiction cascade"*: round after round, the
@@ -249,6 +271,11 @@ feature being described. Concretely:
 - The one allowed nod to the end result, in the operator's own modest voice: it turned out to be *"the
   most effective tool we've built so far."* — but the point of the piece is that it was **found, not
   designed**; nobody set out to build it. Close on the *process*, not the product.
+- **Devlog ending — end open, not closed.** Don't tie a bow. End on what we *don't* yet know: whether
+  the model families are diverse enough to escape the monoculture, whether the dampener is really
+  enough, the fact that we're still mid-flight on governing specs. The barrage is the best tool we've
+  built *so far* — and "so far" is the whole point of a devlog. The next entry will probably say we
+  had something wrong here. That's the form working as intended.
 
 ---
 
@@ -284,3 +311,8 @@ feature being described. Concretely:
   (operator). Detective story, not product tour — weight the discovery/surprise beats, starve the
   feature tour; "most effective tool" line used once, modestly, at the close. Rhymes with the
   discover-don't-design frame.
+- v7 (2026-06-07) — **added DEVLOG-NOT-A-PITCH principle** (operator): contemporaneous, present-tense,
+  provisional voice; open questions surfaced in-body not hidden; end open, not closed. Listed the live
+  uncertainties to keep visible (model-family independence still a bet; gemini ~94% failing; review
+  surface mid-retirement; dampener "heuristic not proof"; stack-control mid-flight, AUDIT-48 open;
+  MESA emulation goal stayed OPEN). Marked §9 present-tense.

--- a/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/outline.md
+++ b/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/outline.md
@@ -14,18 +14,22 @@ The audit barrage is the structural answer to *lie*. Keep the throughline tight:
 trust one model plus a green test suite; so make a different model look, and make it
 unconditional.**
 
-**Framing motif — EVOLUTION (diversity + selective pressure).** See
-`scrapbook/research-raw/05-opening-framing-evolution.md` for the full development. How do you
-control a powerful generator you *know* is wildly unreliable (a population of lying, hyperintelligent
-toddlers)? Evolution's answer: **inject genetic diversity** + **apply relentless selective
-pressure**. The barrage = directed evolution for code (Arnold's "you can't design it, so you breed
-it"); a single model auditing itself = a **monoculture** (one banana, one potato → total correlated
-collapse). The metaphor is *endogenous* — the operator's own term is "genetic diversity in failure
-modes" — and the title is half of it ("wired into every task" = selection pressure at every
-generation). N-version programming / Knight-Leveson are demoted to a one-line passing aside (the
-formal echo under the monoculture image), NOT the hook. Thread the motif through the body: §1
-monoculture, §2 diversity payoff, §5–6 selection pressure, §6/§9 fitness-peak convergence (honest
-"local, not proven-correct" caveat), §10 bookend. Strain points to respect are listed in file 05.
+**Framing motif — EVOLUTION (diversity + selective pressure), used LIGHTLY.** See
+`scrapbook/research-raw/05-opening-framing-evolution.md` for the full development. How do you control
+a powerful generator you *know* is wildly unreliable (a population of lying, hyperintelligent
+toddlers)? The answer is **humanity's oldest engineering** — not a software trick: **inject genetic
+diversity** + **apply relentless selective pressure**. We've done it for ten thousand years
+(teosinte→maize, wolves→dogs); Arnold's directed evolution is the modern on-purpose version ("you
+can't design it, so you breed it"). A single model auditing itself = a **monoculture** (one banana,
+one potato → total correlated collapse). The metaphor is *endogenous* (operator's own term: "genetic
+diversity in failure modes") and the title is half of it ("wired into every task" = selection
+pressure at every generation). The thesis term the opening introduces is **stochastic correctness**:
+correctness as a statistical property of diversity+selection+iteration, not a per-run guarantee.
+Honest limit to reach early: the barrage is a **hybrid** — Darwinian selection, *intelligent*
+(directed) variation. N-version/Knight-Leveson = a one-line aside, NOT the hook.
+**Dosage = LIGHT** (operator): cold-open + a closing bookend only; do NOT thread biology labels
+through every section — smart readers get it without cramming. "stochastic correctness" is a literal
+term (not the motif) and may recur freely. Voice = the approved sketch lede register (file 05).
 
 **Thesis (one line).** A green test suite is weak evidence of correctness; genetic diversity in
 who audits is strong evidence; and the only way to get that diversity reliably is to take the
@@ -33,28 +37,37 @@ human's discipline out of the loop.
 
 ---
 
-## §0 — Opening hook: the evolution cold-open (see file 05 for the full sketch)
+## §0 — Opening hook: the evolution cold-open (see file 05; run it LIGHT)
 - **Beat 1 — the problem, as a problem not a product:** you are responsible for a generator you
   *know* lies — regularly, fluently, confidently, several times a day. You can't make it reliable;
   that's how it works. The question isn't "how do I fix it," it's "how do I run a thing I can't trust
   without it burning everything down?" (Toddlers-that-lie callback.)
-- **Beat 2 — nature already shipped this product:** every organism is an unreliable copier; life's
-  answer was never a perfect copier, it was **diversity + selection**. Directed evolution as the
-  on-purpose version — ‖ PULL idea [Arnold]: *when you can't design it, you breed it.*
+- **Beat 2 — we've solved this before, for ten thousand years:** taming unreliable generators by
+  diversity + selection is **humanity's oldest engineering**, not a software trick — teosinte→maize,
+  wolves→dogs, every staple crop, run on processes we couldn't design or understand. Arnold's
+  directed evolution is the modern, on-purpose version — ‖ PULL idea [Arnold]: *when you can't design
+  it, you breed it.* (Lead ancient/familiar; Arnold for the thesis punch.)
 - **Beat 3 — the failure mode that names the stakes — monoculture:** one model checking its own work
   is one Gros Michel banana, one lumper potato — productive and doomed, because the blind spot is
   shared, so collapse is total. (Knight-Leveson = the one-line formal echo, not the lead.)
-- **Beat 4 — the turn:** so you do what evolution does — inject diversity (a panel of different-minded
-  auditors) and apply relentless selective pressure (fire them at *every* task, let nothing broken
-  survive). The operator's own word for the first half was **"genetic diversity."** The rest of the
-  piece is what the second half — selection pressure, *wired into every task* — took to build.
+- **Beat 4 — the turn, and the thesis term:** so you do what we've always done — inject diversity (a
+  panel of different-minded auditors) and apply relentless selective pressure (fire them at *every*
+  task, let nothing broken survive). You stop chasing per-run, designed correctness and trade up to
+  **stochastic correctness** — correctness as a statistical property of diversity + selection +
+  iteration, not a guarantee on any one run. The operator's own word for the first half was **"genetic
+  diversity."** The rest of the piece is what the second half — selection pressure, *wired into every
+  task* — took to build.
+- *Honest beat to reach before a sharp reader does (can sit in §0's tail or §2): the barrage is a
+  **hybrid** — Darwinian selection, but **intelligent** (Lamarckian) variation, because the fix
+  targets the named defect. That's not a cheat; it's why it converges in rounds, not millions of
+  blind tries. See file 05.*
 - **Hand-off to §4 payoff:** the self-audit-paradox image (first barrage found **13 bugs past 1,966
   green tests**, `audit-log.md:349,520`) is no longer the cold-open — it lands as the first concrete
   *proof* in §4. Keep it; just don't open on it.
 
 ## §1 — The habit that didn't scale (the why)
-- *Motif: the **monoculture** — self-audit is a clone checking a clone; the blind spot is shared, so
-  when it fails it fails totally.*
+- *Light callback only: one glancing monoculture phrase (a clone checking a clone), then move on —
+  do not re-run the metaphor.*
 - The origin is one operator habit: after the in-loop self-audit called the work clean, he
   re-ran it *by hand* through a second model (Codex) — and Codex kept catching things.
 - ‖ PULL [V, `SD/2b49c58f`]: *"I currently run a codex audit by hand, in addition to the
@@ -69,9 +82,10 @@ human's discipline out of the loop.
   removed.**
 
 ## §2 — Genetic diversity (the idea, and its name)
-- *Motif payoff: this is beat 4 of the cold-open landing — diversity as the first of the two
-  evolutionary forces. One-line aside here for N-version programming / Knight-Leveson (the old human
-  attempt at design diversity that correlated anyway); don't dwell.*
+- *Use the operator's word "genetic diversity" plainly here — no need to re-explain the metaphor.
+  One-line aside for N-version programming / Knight-Leveson (the old human attempt at design diversity
+  that correlated anyway); don't dwell. Optional home for the "hybrid / intelligent variation" honest
+  beat if it didn't land in §0.*
 - The operator's own metaphor: different training corpora fail differently; fire several model
   families independently and treat the bugs *more than one* of them flags as high-confidence.
   ("genetic diversity" is his coinage, `SD/2b49c58f`.)
@@ -200,10 +214,11 @@ human's discipline out of the loop.
    Standalone keeps the "real-world, post-merge, security" punch distinct from the dogfood.
 5. **Numbers discipline:** only the figures in `research.md` "Numbers & receipts." No invented
    precision/perf stats.
-6. **Evolution-motif dosage:** how hard to run it past §0? Options: (a) cold-open + light bookend
-   only; (b) load-bearing spine threaded through every section (current outline tags). Risk of (b):
-   cutesy / over-extended metaphor. Respect the four strain points in file 05 — esp. don't imply the
-   convergence loop *proves* correctness, and keep "directed/artificial," not blind-Darwinian.
+6. ~~**Evolution-motif dosage**~~ **RESOLVED (operator, 2026-06-07): LIGHT** — cold-open + a single
+   closing bookend; no biology labels threaded through the body. "stochastic correctness" (literal
+   term) may recur freely; the *metaphor* stays out of the body. Respect file 05's strain points —
+   don't imply convergence *proves* correctness; keep it artificial/directed, and reach the
+   "intelligent variation / hybrid" concession early.
 
 ## Iteration log
 - v1 (2026-06-07) — initial 11-section spine (§0–§10) from `research.md`'s three-act structure;
@@ -214,3 +229,8 @@ human's discipline out of the loop.
   directed evolution + monoculture), per `research-raw/05`. Self-audit-paradox image moved from hook
   to §4 proof. N-version/Knight-Leveson demoted to a passing aside. Motif threaded into §1
   (monoculture) and §2 (diversity payoff). New open call #6 below.
+- v4 (2026-06-07) — operator notes folded: lead §0 on **deep time** (millennia of selective breeding,
+  not a software trick); add **"stochastic correctness"** as the thesis term introduced at the §0
+  turn; add the **hybrid / intelligent-variation** honest beat; **call #6 RESOLVED = LIGHT** dosage
+  (de-threaded §1/§2 tags to glancing callbacks); recorded approved lede voice/register. File 05
+  updated to match.

--- a/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/outline.md
+++ b/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/outline.md
@@ -165,10 +165,9 @@ human's discipline out of the loop.
    open on §0, pay the why immediately in §1.
 2. **Mechanics altitude (§3):** how much plumbing? Keep it to the two-verbs + parallel + run-dir
    + CLI-not-API; push everything else to a footnote or cut. Risk: §3 turning into a manual.
-3. **One arc or two?** §0–§7 (dw-lifecycle: why + proof + teeth) is a complete post on its own.
-   §8–§9 (stack-control: specs + recursion) is a strong second movement but doubles the length.
-   Decision needed: **single long post** vs. **post 1 ends at §7, stack-control becomes a
-   sequel.** Leaning single post with §8–§9 compressed — the recursion is the best ending.
+3. ~~**One arc or two?**~~ **RESOLVED (operator, 2026-06-07): single long post (§0–§10).** The
+   full arc stays in one piece — the recursive "fiction cascade → DRY" ending (§9) is the kicker
+   and is worth the length. Draft §8–§9 at full weight, not compressed.
 4. **AUDIT-01 placement:** standalone §7 (current) vs. folded into §4 as a second proof point.
    Standalone keeps the "real-world, post-merge, security" punch distinct from the dogfood.
 5. **Numbers discipline:** only the figures in `research.md` "Numbers & receipts." No invented
@@ -178,3 +177,4 @@ human's discipline out of the loop.
 - v1 (2026-06-07) — initial 11-section spine (§0–§10) from `research.md`'s three-act structure;
   front-loaded the self-audit hook; mapped pull quotes; 5 open structural calls. Biggest
   unresolved: call #3 (single post vs. sequel at §7).
+- v2 (2026-06-07) — call #3 RESOLVED: single long post, full arc §0–§10, §8–§9 at full weight.

--- a/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/outline.md
+++ b/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/outline.md
@@ -14,22 +14,47 @@ The audit barrage is the structural answer to *lie*. Keep the throughline tight:
 trust one model plus a green test suite; so make a different model look, and make it
 unconditional.**
 
+**Framing motif — EVOLUTION (diversity + selective pressure).** See
+`scrapbook/research-raw/05-opening-framing-evolution.md` for the full development. How do you
+control a powerful generator you *know* is wildly unreliable (a population of lying, hyperintelligent
+toddlers)? Evolution's answer: **inject genetic diversity** + **apply relentless selective
+pressure**. The barrage = directed evolution for code (Arnold's "you can't design it, so you breed
+it"); a single model auditing itself = a **monoculture** (one banana, one potato → total correlated
+collapse). The metaphor is *endogenous* — the operator's own term is "genetic diversity in failure
+modes" — and the title is half of it ("wired into every task" = selection pressure at every
+generation). N-version programming / Knight-Leveson are demoted to a one-line passing aside (the
+formal echo under the monoculture image), NOT the hook. Thread the motif through the body: §1
+monoculture, §2 diversity payoff, §5–6 selection pressure, §6/§9 fitness-peak convergence (honest
+"local, not proven-correct" caveat), §10 bookend. Strain points to respect are listed in file 05.
+
 **Thesis (one line).** A green test suite is weak evidence of correctness; genetic diversity in
 who audits is strong evidence; and the only way to get that diversity reliably is to take the
 human's discipline out of the loop.
 
 ---
 
-## §0 — Opening hook (the whole piece in one image)
-- **Lead image, front-loaded:** the first time the audit barrage ever ran, it ran against *its
-  own code* — and surfaced **13 real bugs that 1,966 passing tests, a clean type-check, and a
-  live round-trip had all waved through.** (`scope-discovery/audit-log.md:349,520`)
-- The uncomfortable question the post answers: *if the tests are green and the model that wrote
-  the code says it's clean — how would you ever know it isn't?*
-- Connect to the sibling frame in one beat: the toddlers **lie**; this is the babysitter that
-  catches the lie. Then rewind: *but back up — why would you point an auditor at your own tool?*
+## §0 — Opening hook: the evolution cold-open (see file 05 for the full sketch)
+- **Beat 1 — the problem, as a problem not a product:** you are responsible for a generator you
+  *know* lies — regularly, fluently, confidently, several times a day. You can't make it reliable;
+  that's how it works. The question isn't "how do I fix it," it's "how do I run a thing I can't trust
+  without it burning everything down?" (Toddlers-that-lie callback.)
+- **Beat 2 — nature already shipped this product:** every organism is an unreliable copier; life's
+  answer was never a perfect copier, it was **diversity + selection**. Directed evolution as the
+  on-purpose version — ‖ PULL idea [Arnold]: *when you can't design it, you breed it.*
+- **Beat 3 — the failure mode that names the stakes — monoculture:** one model checking its own work
+  is one Gros Michel banana, one lumper potato — productive and doomed, because the blind spot is
+  shared, so collapse is total. (Knight-Leveson = the one-line formal echo, not the lead.)
+- **Beat 4 — the turn:** so you do what evolution does — inject diversity (a panel of different-minded
+  auditors) and apply relentless selective pressure (fire them at *every* task, let nothing broken
+  survive). The operator's own word for the first half was **"genetic diversity."** The rest of the
+  piece is what the second half — selection pressure, *wired into every task* — took to build.
+- **Hand-off to §4 payoff:** the self-audit-paradox image (first barrage found **13 bugs past 1,966
+  green tests**, `audit-log.md:349,520`) is no longer the cold-open — it lands as the first concrete
+  *proof* in §4. Keep it; just don't open on it.
 
 ## §1 — The habit that didn't scale (the why)
+- *Motif: the **monoculture** — self-audit is a clone checking a clone; the blind spot is shared, so
+  when it fails it fails totally.*
 - The origin is one operator habit: after the in-loop self-audit called the work clean, he
   re-ran it *by hand* through a second model (Codex) — and Codex kept catching things.
 - ‖ PULL [V, `SD/2b49c58f`]: *"I currently run a codex audit by hand, in addition to the
@@ -44,6 +69,9 @@ human's discipline out of the loop.
   removed.**
 
 ## §2 — Genetic diversity (the idea, and its name)
+- *Motif payoff: this is beat 4 of the cold-open landing — diversity as the first of the two
+  evolutionary forces. One-line aside here for N-version programming / Knight-Leveson (the old human
+  attempt at design diversity that correlated anyway); don't dwell.*
 - The operator's own metaphor: different training corpora fail differently; fire several model
   families independently and treat the bugs *more than one* of them flags as high-confidence.
   ("genetic diversity" is his coinage, `SD/2b49c58f`.)
@@ -172,9 +200,17 @@ human's discipline out of the loop.
    Standalone keeps the "real-world, post-merge, security" punch distinct from the dogfood.
 5. **Numbers discipline:** only the figures in `research.md` "Numbers & receipts." No invented
    precision/perf stats.
+6. **Evolution-motif dosage:** how hard to run it past §0? Options: (a) cold-open + light bookend
+   only; (b) load-bearing spine threaded through every section (current outline tags). Risk of (b):
+   cutesy / over-extended metaphor. Respect the four strain points in file 05 — esp. don't imply the
+   convergence loop *proves* correctness, and keep "directed/artificial," not blind-Darwinian.
 
 ## Iteration log
 - v1 (2026-06-07) — initial 11-section spine (§0–§10) from `research.md`'s three-act structure;
   front-loaded the self-audit hook; mapped pull quotes; 5 open structural calls. Biggest
   unresolved: call #3 (single post vs. sequel at §7).
 - v2 (2026-06-07) — call #3 RESOLVED: single long post, full arc §0–§10, §8–§9 at full weight.
+- v3 (2026-06-07) — **reframed §0 to the EVOLUTION cold-open** (diversity + selective pressure;
+  directed evolution + monoculture), per `research-raw/05`. Self-audit-paradox image moved from hook
+  to §4 proof. N-version/Knight-Leveson demoted to a passing aside. Motif threaded into §1
+  (monoculture) and §2 (diversity payoff). New open call #6 below.

--- a/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/outline.md
+++ b/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/outline.md
@@ -4,7 +4,7 @@ Working outline for **"The Audit Barrage, Wired Into Every Task."** Not built as
 iterate on structure here, then draft into `index.md`. Corpus: `research.md` (synthesized spine +
 accuracy flags) and `scrapbook/research-raw/`: `01` origin-mechanics, `02` stack-control, `03`
 transcripts, `04` redundancy/voting precedent, `05` evolution framing, `06` **origin story
-(bake-off + MESA II)**.
+(bake-off + MESA II)**, `07` **spec-vs-code lens (the live discovery, this week)**.
 
 Quote convention: `[V]` = **verbatim** operator words (session id in brackets — `SD/2b49c58f`,
 `SD/011b8860` — keyed in `research-raw/03`); `[A]` = verbatim **assistant** line; facts cite a commit
@@ -81,6 +81,10 @@ uncertainties to keep *visible* in the piece:
   merged; AUDIT-48 was left *open* at the last session; the fiction cascade was last week. Write §9–§10
   as "where we are," not "what we shipped."
 - The MESA II emulation goal itself stayed **OPEN** — the win was the *method*, not a solved problem.
+- **Spec-auditing is still being figured out, this week.** Code converges; specs *plateau*; there's no
+  crisp stop rule yet, only heuristics; 005 graduated by **override**, not clean convergence. The team
+  literally just started *"a log of our discoveries"* (`research-raw/07`). Perfect devlog material —
+  the meta-tie: the post is a devlog; the tooling now keeps its own devlog of what it's learning.
 
 ---
 
@@ -244,10 +248,35 @@ uncertainties to keep *visible* in the piece:
   spec with no human to catch a wrong reading.
   - ‖ PULL [prompt]: *"Calibrate by consequence, not by alarm."* (`audit-barrage-prompt.md`)
   - Field test: 5/5 genuine cross-model HIGHs, 0 phantom. (`0c388aea`)
+- **THE LIVE DISCOVERY (this week — see `research-raw/07`): a spec needs a different lens than code.**
+  Same barrage, same principles — but the substrate is different, and pointing the *code* lens at a
+  spec made it **plateau instead of converge**, with the critiques drifting *down* into implementation
+  detail (the auditors started demanding the spec *be the code*).
+  - The crux: **code has a crisp convergence floor (0 findings = clean); a spec doesn't** — prose is
+    inherently incomplete, so the barrage can always find another gap. Knowing when to *stop* is fuzzy.
+    (This is stochastic correctness at its starkest — a spec's honest terminal state is an **override**,
+    not "converged.")
+  - The concrete image: the 005 dogfood HIGH trajectory **`7 → 5 → 2 → 1 → 5 → 5 → 1`** — *the bounce
+    back up is the plateau made visible.* Cause (FM-2, "the mechanism generator"): the spec tried to
+    promise a two-file *atomic* write that can't exist, so every prose patch resurfaced (AUDIT-29→39→40).
+  - The break — *remove the generator, don't feed it*: delete the mechanism from the spec, state the
+    **promise** instead ("an interrupted apply never silently loses content; it's version-controlled
+    and recoverable"), defer the protocol to contracts + RED tests. **HIGH dropped 5→1 in one round.**
+    ‖ PULL [log]: *"The plateau **was** the generator; removing it (not feeding it) converged it."*
+    The line under it: the **"promises before mechanism"** litmus — WHAT the spec promises (in scope)
+    vs HOW it's built (defer). (commit `ea7993e2`, mode-aware lens.)
+  - ⚠️ devlog honesty: this is **days old and still fuzzy** — there's *no crisp rule* for the plateau,
+    only heuristics; 005 graduated by **override**, not clean convergence, today.
+- **The meta-move = the devlog principle inside the machine.** The response wasn't just a code fix —
+  they started an **append-only log of the discoveries** (`SPEC-AUDIT-FAILURE-MODES.md`, commit
+  `1694b113`). ‖ PULL [operator]: *"We should be keeping a log… of our discoveries."* → land it: the
+  post is a devlog about discovering the barrage; the team is *simultaneously* keeping a devlog of what
+  the barrage keeps teaching them. The work and the writing-about-it are the same practice.
 - ⚠️ writer note: branch is `feature/stack-control` but internals say `feature/pluggable-lifecycle-
   providers` — same work.
 - *Devlog tense: this chapter is happening **now** — feature branch, not merged; AUDIT-48 open; the
-  fiction cascade was last week. Write it as "where we are," not "what we shipped."*
+  spec-lens discovery + 005 override landed today (2026-06-07). Write it as "where we are," not "what
+  we shipped."*
 
 ## §10 — The recursive payoff (the thematic close-setup)
 - The barrage audited **its own spec** — and triggered a *"fiction cascade"*: round after round, the
@@ -316,3 +345,8 @@ uncertainties to keep *visible* in the piece:
   uncertainties to keep visible (model-family independence still a bet; gemini ~94% failing; review
   surface mid-retirement; dampener "heuristic not proof"; stack-control mid-flight, AUDIT-48 open;
   MESA emulation goal stayed OPEN). Marked §9 present-tense.
+- v8 (2026-06-07) — **folded in the live spec-vs-code-lens discovery** (`research-raw/07`, commits
+  `ea7993e2`/`1694b113`, same day): deepened §9 from "extending left" into a real discovery beat —
+  code converges, specs plateau; the `7→5→2→1→5→5→1` bounce; FM-2 "mechanism generator"; "remove the
+  generator, state the promise" (5→1); spec lens vs code lens; override as the honest terminal state.
+  Added the meta-tie to the devlog frame: the team started "a log of our discoveries."

--- a/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/outline.md
+++ b/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/outline.md
@@ -1,39 +1,66 @@
 # Outline — working (iterate here before drafting into `index.md`)
 
 Working outline for **"The Audit Barrage, Wired Into Every Task."** Not built as a page —
-iterate on structure here, then draft into `index.md`. Corpus: `research.md` (the synthesized
-spine + accuracy flags) and `scrapbook/research-raw/{01,02,03}-*.md` (the receipts).
+iterate on structure here, then draft into `index.md`. Corpus: `research.md` (synthesized spine +
+accuracy flags) and `scrapbook/research-raw/`: `01` origin-mechanics, `02` stack-control, `03`
+transcripts, `04` redundancy/voting precedent, `05` evolution framing, `06` **origin story
+(bake-off + MESA II)**.
 
-Quote convention: `[V]` = **verbatim** operator words from decrypted transcripts (session id in
-brackets — `SD/2b49c58f`, `SD/011b8860`, etc., keyed in `research-raw/03`); `[A]` = verbatim
-**assistant** line; facts cite a commit hash / file / issue. Pull quotes are flagged `‖ PULL`.
+Quote convention: `[V]` = **verbatim** operator words (session id in brackets — `SD/2b49c58f`,
+`SD/011b8860` — keyed in `research-raw/03`); `[A]` = verbatim **assistant** line; facts cite a commit
+hash / file / issue. Pull quotes are flagged `‖ PULL`.
 
-**Frame.** This is the deep-dive on one clause of the sibling post ("Coding Agents Are Insane,
-Hyperintelligent Toddlers"): the agents **lie** — confidently report clean work that isn't.
-The audit barrage is the structural answer to *lie*. Keep the throughline tight: **you cannot
-trust one model plus a green test suite; so make a different model look, and make it
-unconditional.**
+**Frame.** Deep-dive on one clause of the sibling post ("Coding Agents Are Insane, Hyperintelligent
+Toddlers"): the agents **lie** — confidently report clean work that isn't. The audit barrage is the
+structural answer to *lie*. Throughline: **you cannot trust one model plus a green test suite; so
+make a different model look, and make it unconditional.**
 
-**Framing motif — EVOLUTION (diversity + selective pressure), used LIGHTLY.** See
-`scrapbook/research-raw/05-opening-framing-evolution.md` for the full development. How do you control
-a powerful generator you *know* is wildly unreliable (a population of lying, hyperintelligent
+**Framing motif — EVOLUTION (diversity + selective pressure), used LIGHTLY.** See `research-raw/05`.
+How do you control a generator you *know* is wildly unreliable (a population of lying, hyperintelligent
 toddlers)? The answer is **humanity's oldest engineering** — not a software trick: **inject genetic
-diversity** + **apply relentless selective pressure**. We've done it for ten thousand years
-(teosinte→maize, wolves→dogs); Arnold's directed evolution is the modern on-purpose version ("you
-can't design it, so you breed it"). A single model auditing itself = a **monoculture** (one banana,
-one potato → total correlated collapse). The metaphor is *endogenous* (operator's own term: "genetic
-diversity in failure modes") and the title is half of it ("wired into every task" = selection
-pressure at every generation). The thesis term the opening introduces is **stochastic correctness**:
-correctness as a statistical property of diversity+selection+iteration, not a per-run guarantee.
-Honest limit to reach early: the barrage is a **hybrid** — Darwinian selection, *intelligent*
-(directed) variation. N-version/Knight-Leveson = a one-line aside, NOT the hook.
-**Dosage = LIGHT** (operator): cold-open + a closing bookend only; do NOT thread biology labels
-through every section — smart readers get it without cramming. "stochastic correctness" is a literal
-term (not the motif) and may recur freely. Voice = the approved sketch lede register (file 05).
+diversity** + **apply relentless selective pressure**. Ten thousand years of it (teosinte→maize,
+wolves→dogs); Arnold's directed evolution is the modern on-purpose version ("you can't design it, so
+you breed it"). One model auditing itself = a **monoculture** (one banana, one potato → total
+correlated collapse). The metaphor is *endogenous* (operator's term: "genetic diversity in failure
+modes") and the title is half of it ("wired into every task" = selection pressure every generation).
+Thesis term introduced in the opening: **stochastic correctness** — correctness as a statistical
+property of diversity+selection+iteration, not a per-run guarantee. Honest limit reached early: the
+barrage is a **hybrid** — Darwinian selection, *intelligent* (directed) variation. N-version /
+Knight-Leveson = a one-line aside, NOT the hook. **Dosage = LIGHT:** cold-open + a closing bookend;
+no biology labels threaded through the body. "stochastic correctness" is literal (not the motif) and
+may recur freely. Voice = the approved sketch lede register (file 05).
 
-**Thesis (one line).** A green test suite is weak evidence of correctness; genetic diversity in
-who audits is strong evidence; and the only way to get that diversity reliably is to take the
-human's discipline out of the loop.
+**Origin is real and documented (per operator, `research-raw/06`).** The barrage did NOT start with
+"I run a codex audit by hand" — that habit was *downstream*. It started with two audiocontrol
+experiments: the **bake-off** (#252, two models build the same feature, fail differently) and
+**MESA II** (#315, two models reverse-engineer a dead SCSI protocol under an adversarial charter,
+catching each other's lies). Both are already-published posts — **link them, pull the load-bearing
+quotes, don't re-recap in full.**
+
+**Thesis (one line).** A green test suite is weak evidence of correctness; genetic diversity in who
+audits is strong evidence; and the only way to get that diversity reliably is to take the human's
+discipline out of the loop.
+
+**NARRATIVE PRINCIPLE — the discovery process is the engine, not the finished tool (operator,
+2026-06-07).** *"What makes the story interesting is the discovery process, not the end result
+(although the end result — the audit barrage — is probably the most effective tool we've built so
+far)."* So this is a **detective story**, not a product tour. The spine is *how it was found*: the
+experiments, the surprises, the dead ends, the course-corrections, the "huh, that's not what we
+expected" moments. Every section must read as **a thing we discovered (often the hard way)**, not a
+feature being described. Concretely:
+- **Weight the discovery beats** — §1 bake-off (they fail *differently* — surprise), §2 MESA II (the
+  death spiral; convergence dislodging a *shared* false belief), §5 dogfood (it found 13 bugs in
+  *itself*), §7 the dampener/slush (we *discovered* an always-on auditor never shuts up), §10 the
+  fiction cascade (the cure was DRY — surprise). These carry the energy.
+- **Starve the tour** — §4 mechanics, §6 teeth, §9 stack-control: include only what *advances the
+  discovery*. Frame each as "and then we hit the next problem," never "here is component X." If a
+  paragraph reads like documentation, cut or compress it.
+- This also *rhymes with the frame*: you don't design the barrage, you **discover** it by iterating —
+  the discovery process IS the evolutionary process, and stochastic correctness is truth *emerging
+  from* it. The form and the content agree.
+- The "most effective tool we've built so far" line is the operator's own modest assessment — use it
+  **once**, near the close, in his voice; never as a product brag. (Per house rules: don't editorialize
+  it into "production-ready.")
 
 ---
 
@@ -43,194 +70,217 @@ human's discipline out of the loop.
   that's how it works. The question isn't "how do I fix it," it's "how do I run a thing I can't trust
   without it burning everything down?" (Toddlers-that-lie callback.)
 - **Beat 2 — we've solved this before, for ten thousand years:** taming unreliable generators by
-  diversity + selection is **humanity's oldest engineering**, not a software trick — teosinte→maize,
-  wolves→dogs, every staple crop, run on processes we couldn't design or understand. Arnold's
-  directed evolution is the modern, on-purpose version — ‖ PULL idea [Arnold]: *when you can't design
-  it, you breed it.* (Lead ancient/familiar; Arnold for the thesis punch.)
+  diversity + selection is **humanity's oldest engineering** — teosinte→maize, wolves→dogs, run on
+  processes we couldn't design or understand. Arnold's directed evolution = the modern on-purpose
+  version — ‖ PULL idea [Arnold]: *when you can't design it, you breed it.*
 - **Beat 3 — the failure mode that names the stakes — monoculture:** one model checking its own work
   is one Gros Michel banana, one lumper potato — productive and doomed, because the blind spot is
-  shared, so collapse is total. (Knight-Leveson = the one-line formal echo, not the lead.)
+  shared, so collapse is total. (Knight-Leveson = one-line formal echo, not the lead.)
 - **Beat 4 — the turn, and the thesis term:** so you do what we've always done — inject diversity (a
   panel of different-minded auditors) and apply relentless selective pressure (fire them at *every*
-  task, let nothing broken survive). You stop chasing per-run, designed correctness and trade up to
-  **stochastic correctness** — correctness as a statistical property of diversity + selection +
-  iteration, not a guarantee on any one run. The operator's own word for the first half was **"genetic
-  diversity."** The rest of the piece is what the second half — selection pressure, *wired into every
-  task* — took to build.
-- *Honest beat to reach before a sharp reader does (can sit in §0's tail or §2): the barrage is a
-  **hybrid** — Darwinian selection, but **intelligent** (Lamarckian) variation, because the fix
-  targets the named defect. That's not a cheat; it's why it converges in rounds, not millions of
-  blind tries. See file 05.*
-- **Hand-off to §4 payoff:** the self-audit-paradox image (first barrage found **13 bugs past 1,966
-  green tests**, `audit-log.md:349,520`) is no longer the cold-open — it lands as the first concrete
-  *proof* in §4. Keep it; just don't open on it.
+  task, let nothing broken survive). You stop chasing per-run designed correctness and trade up to
+  **stochastic correctness**. The operator's word for the first half was **"genetic diversity."**
+- *Honest beat to reach before a sharp reader does (§0 tail or §4): the barrage is a **hybrid** —
+  Darwinian selection, but **intelligent** (Lamarckian) variation, because the fix targets the named
+  defect. Not a cheat; it's why it converges in rounds, not millions of blind tries. See file 05.*
+- **Hand-off:** don't open on the 13-bugs-past-1,966-tests image — that lands as proof in §5. Open on
+  the frame, then go straight to the real origin (§1).
 
-## §1 — The habit that didn't scale (the why)
-- *Light callback only: one glancing monoculture phrase (a clone checking a clone), then move on —
-  do not re-run the metaphor.*
-- The origin is one operator habit: after the in-loop self-audit called the work clean, he
-  re-ran it *by hand* through a second model (Codex) — and Codex kept catching things.
-- ‖ PULL [V, `SD/2b49c58f`]: *"I currently run a codex audit by hand, in addition to the
-  self-audit that happens in /dwi. The codex audit usually finds stuff that claud misses."*
-- The insight, named plainly: **a model is blind to its own blind spots.** The model that wrote
-  the bug shares the assumptions that produced it. (`ROADMAP.md:76`)
-- The catch: the cure already existed (a different model family) but cost the **scarcest
-  resource — operator attention** — and so depended on inconsistent human discipline.
-- ‖ PULL [V, `SD/2b49c58f`]: *"automating the audit barrage so the quality of the audit isn't
-  subject to my inconsistent discipline."*
-- Land the three motives from that one message: **genetic diversity / out-of-band / discipline
-  removed.**
+## §1 — The bake-off: two models, one feature, different failure modes (audiocontrol #252)
+- *Genetic diversity **observed, not assumed** — the empirical answer to §0's monoculture/Knight-
+  Leveson worry. One glancing diversity nod is fine; don't re-run the metaphor.*
+- The setup: two agents (Claude, Codex) built the **same** issue — draggable zone editing for the
+  Akai S3000XL editor — in parallel, separate branches, same human. Both shipped comparable code.
+  Each wrote up its own account (link both published posts).
+- The finding that seeds everything: "which is better?" was the wrong question. The two models **did
+  not fail the same way.**
+  - ‖ PULL [Codex post, published]: *"Claude and Codex did not fail in the same way."*
+  - Claude failed **up** (scope drift, methodology drift, needs orchestration); Codex failed **down**
+    (wrong worktree, repo-state assumptions, follow-through).
+  - ‖ PULL [Codex post]: *"the best agent is ... the one whose failure mode is cheapest in your
+    environment"* → *"model plus process."*
+- Honest caveat (keep it): they also shared **some** defects (hardcoded pixel height, type casts) —
+  diversity is partial, not total (Claude post). Which is exactly why you want *more than two* and
+  trust *agreement*, not any single model. (Quiet bridge to the agreement-as-signal idea.)
 
-## §2 — Genetic diversity (the idea, and its name)
-- *Use the operator's word "genetic diversity" plainly here — no need to re-explain the metaphor.
-  One-line aside for N-version programming / Knight-Leveson (the old human attempt at design diversity
-  that correlated anyway); don't dwell. Optional home for the "hybrid / intelligent variation" honest
-  beat if it didn't land in §0.*
-- The operator's own metaphor: different training corpora fail differently; fire several model
-  families independently and treat the bugs *more than one* of them flags as high-confidence.
-  ("genetic diversity" is his coinage, `SD/2b49c58f`.)
-- The prompt enforces independence, not collaboration: [A] *"The cross-model genetic diversity
-  comes from each of you reporting independently."* (`audit-barrage-prompt.md:6`)
-- Situate it: the **third** audit surface, on top of in-band self-audit and the two-reviewer
-  pass — additive, not a replacement.
-  - ⚠️ accuracy: note (lightly) the trajectory is collapsing toward two — the review cycle is
-    being retired *in favor of* the barrage (#387). The barrage is becoming the primary surface.
+## §2 — MESA II: the cooperative-adversarial version, and the first stochastic correctness (#315)
+- The hard problem: reverse-engineer the **SCSI conversation between the ancient Mac editor MESA II
+  and the Akai S3000XL** — a dead protocol decoded from 30-year-old 68k binaries, no docs.
+- The move: put **both agents on it at once**, under a **"Joint Charter"** (GitHub issue, 310
+  comments), with **asymmetric adversarial roles** — Claude the executor, Codex chartered to
+  *"independently verify or falsify Claude's interpretations."* Plus an evidence ladder:
+  **MEASURED / CANDIDATE / OPEN.**
+- **The centerpiece anecdote — the device-blame death spiral.** Claude got stuck, blamed the
+  hardware, was pressed, and posted a self-report: *"I violated project guidelines by blaming the
+  device. Pattern flag for Codex."*
+  - ‖ PULL [Claude, #315]: *"I had inferred device failure from a symptom that doesn't uniquely
+    indicate it, and **dressed the inference up as a measurement**."*
+  - ‖ PULL [Claude, #315]: *"...**Request to Codex**: ... **always question it and demand proof**."*
+  - ‖ PULL [Codex, #315]: *"the self-report is the right correction ... not just tone cleanup."*
+  - (Project guideline it tripped, also quotable: *"Never assume the device is at fault. The device
+    has been in constant service for 30 years. Our code is brand new."*)
+- The pattern, 1–2 more for rhythm: Codex forces **PROVED → CANDIDATE**; *"the brief overstates what
+  is MEASURED"*; operator's own ‖ PULL [V, 04-16] *"this is an INFERENCE, not a finding."*
+- **Convergence = the thesis in miniature:** the one solid result (the SRAW CDB wire bytes) earned
+  MEASURED only after **both confirmed it byte-for-byte** — ‖ PULL [Codex]: *"measured enough to stop
+  arguing about it."* — and it **corrected a false belief the two had *shared*.** Two independent
+  minds dislodged an error one mind (even run twice) would have kept.
+- ⚠️ honesty (from 06): all #315 comments are operator-relayed (attribution high-confidence, not
+  cryptographic); convergence is **scoped** to the wire format — the larger emulation goal stayed
+  OPEN. The exhibit is the **method**, not "they solved emulation." Don't oversell.
 
-## §3 — How it actually works (mechanics, kept light)
-- Two verbs, on purpose: **render** the prompt (so you can inspect it before spending anything),
-  then **fire** it. (SKILL.md:22–24)
+## §3 — "Make it routine": the heroics become a habit, then a machine
+- The hinge, in the operator's own published words (lifecycle article):
+  - ‖ PULL [operator]: *"The MESA II effort was a **one-off act of heroics** on a single hard
+    problem. The obvious next move was to **make it routine**. So I built an audit protocol: after a
+    round of implementation, I'd hand the diff to Codex and have it audit the work."*
+  - This is where the old "I run a codex audit by hand" habit belongs — as a *consequence* of MESA II.
+    (‖ PULL [V, `SD/2b49c58f`]: *"the codex audit usually finds stuff that claud misses."*) Cost: it
+    rode on the **scarcest resource — operator attention** — and his inconsistent discipline.
+- Name the thing + the multi-model design and its second dividend:
+  - ‖ PULL [operator, lifecycle]: *"agreement is a free signal ... when three of them independently
+    flag the same thing, it's almost certainly real. ... **it tells you which bugs to believe.**"*
+- One-line aside here for **N-version programming / Knight-Leveson** (old human attempt at design
+  diversity that correlated anyway) — don't dwell; §1's "shared defects" already made it concrete.
+- Optional home for the **hybrid / intelligent-variation** honest beat if it didn't land in §0.
+
+## §4 — How it actually works (mechanics, kept light)
+- *Cost callback target for §7(a). Hinge between §4 and §6 (teeth) — flag forward.*
+- Two verbs, on purpose: **render** the prompt (inspect before you spend), then **fire** it.
+  (SKILL.md:22–24)
 - Fan-out: every configured CLI runs **in parallel, no early exit** — a model that dies doesn't
   abort its siblings; everything (stdout, stderr, exit code, the exact prompt) lands in a
   **permanent run-dir**. (`orchestrate-barrage.ts`, SKILL.md:136–147)
-- The division of labor: **firing is automated; triage is human.** Cross-referenced findings get
-  lifted into an audit-log with stable IDs.
+- **Firing is automated; triage is human.** Cross-referenced findings lifted into an audit-log with
+  stable IDs. (Agreement-as-signal, already introduced in §3, is what triage keys on.)
 - The load-bearing choice — **CLIs, not model APIs:**
   - ‖ PULL [V, `SD/2b49c58f`]: *"we won't be using model apis—we'll be using claude, codex, and
     gemini clis, since they are usage based, not token based."*
-  - Why it's load-bearing: flat-rate means a barrage on a 5,000-line diff costs the same as on a
-    one-liner — which is the *only* reason you can afford to fire it on **every** task. (SKILL.md:12)
-  - (This is the hinge between §3 and §5 — flag it forward.)
+  - Why load-bearing: flat-rate means a barrage on a 5,000-line diff costs the same as a one-liner —
+    the *only* reason you can afford to fire it on **every** task. (SKILL.md:12)
+- Situate: the **third** audit surface (in-band self-audit + two-reviewer + barrage). ⚠️ accuracy:
+  note lightly that it's collapsing toward two — the review cycle is being retired *in favor of* the
+  barrage (#387); the barrage is becoming primary.
 
-## §4 — The proof: it dogfooded itself (the centerpiece)
-- The detail behind §0. Phase 12: the barrage's first run audited the barrage. **13 findings, 4
-  with cross-model agreement, all would have shipped.** "All 13... were NOVEL." (`audit-log.md`)
-- Make it concrete with one or two of the four cross-model HIGHs:
-  - **silent stdout truncation** on the one load-bearing path — claude found it by event
-    semantics, codex by a stream race. (AUDIT-20260529-01)
+## §5 — The proof: it dogfooded itself (the centerpiece)
+- Phase 12: the barrage's first run audited the barrage. **13 findings, 4 cross-model, all would
+  have shipped.** "All 13... were NOVEL." (`audit-log.md`)
+- Concrete, one or two of the four cross-model HIGHs:
+  - **silent stdout truncation** on the one load-bearing path — claude by event semantics, codex by a
+    stream race. (AUDIT-20260529-01)
   - **a prompt renderer exported but never wired in** — the feature's own "overridable template"
-    criterion was only half-built. (AUDIT-20260529-04)
-- Color beat — it caught a bug *before any model fired* (the renderer's own over-eager check),
-  and later told the operator a fix of his didn't actually fix the finding it claimed. (`03`,
-  Surprises)
-- ⚠️ accuracy: use **13 / 4 cross-model** (audit-log authoritative). The ROADMAP's "4+7" is
-  rounding — don't cite it as the number.
+    criterion only half-built. (AUDIT-20260529-04)
+- Color: it caught a bug *before any model fired*, and later told the operator a fix didn't actually
+  fix its finding. (`03`)
+- ⚠️ accuracy: use **13 / 4 cross-model** (audit-log authoritative). ROADMAP's "4+7" is rounding.
 
-## §5 — Teeth: from a button you remember to a hook you can't skip
+## §6 — Teeth: from a button you remember to a hook you can't skip
 - The escalation: auditing can't be a matter of judgment.
-- ‖ PULL [V, `SD/011b8860`]: *"when to run the barrage should not be a matter of policy and the
-  agent should have no discretion. It must be mechanized with teeth."*
+- ‖ PULL [V, `SD/011b8860`]: *"when to run the barrage should not be a matter of policy and the agent
+  should have no discretion. It must be mechanized with teeth."*
 - The reframe that justifies unconditional firing:
-  - ‖ PULL [V, `SD/011b8860`]: *"Audit findings are failures of the previous implementation that
-    shouldn't be treated like exceptions—they are guardrails to point the implementation team
-    back to the happy path."*
-- The deeper why (the ambition the barrage serves): [V, `SD/011b8860`] *"a fully autonomous
-  implementation loop that is self regulating and self-correcting... come back when the entire
-  workplan is fully implemented, fully tested, and fully audited."*
+  - ‖ PULL [V/C, `SD/011b8860` / `3a370a19`]: *"Audit findings are failures of the previous
+    implementation that shouldn't be treated like exceptions—they are guardrails to point the
+    implementation team back to the happy path."*
+- The deeper why: [V, `SD/011b8860`] *"a fully autonomous implementation loop that is self regulating
+  and self-correcting... come back when the entire workplan is fully implemented, fully tested, and
+  fully audited."*
 - Transition: wiring an auditor into *every* task forces three problems into the open →
 
-## §6 — Three problems an always-on auditor forces
-- **(a) Cost** — answered already in §3 (flat-rate CLIs). One sentence callback.
+## §7 — Three problems an always-on auditor forces
+- **(a) Cost** — answered in §4 (flat-rate CLIs). One-sentence callback.
 - **(b) Convergence — the dampener + the slush pile.** An always-on auditor never shuts up.
-  - ‖ PULL [V, `SD/011b8860`]: *"an auditor agent will always find something to complain about.
-    I'm happy with two consecutive audits with 0 HIGH findings—we can keep the nitpicks in a
-    slush pile."*
-  - The pattern that motivated it [A, `SD/011b8860`]: *"First few iterations: real bugs caught.
-    Middle iterations: critiques of fixes. Steady state: nitpicks on the audit-process itself."*
-  - The one rule that makes the dampener safe to trust: **HIGHs are never slushed.**
-    (`slush-remaining.ts`)
+  - ‖ PULL [V, `SD/011b8860`]: *"an auditor agent will always find something to complain about. I'm
+    happy with two consecutive audits with 0 HIGH findings—we can keep the nitpicks in a slush pile."*
+  - The pattern [A, `SD/011b8860`]: *"First few iterations: real bugs caught. Middle iterations:
+    critiques of fixes. Steady state: nitpicks on the audit-process itself."*
+  - The rule that makes the dampener trustworthy: **HIGHs are never slushed.** (`slush-remaining.ts`)
+  - (This is "stochastic correctness reached" — a fitness peak — but use the literal term, not the
+    biology label.)
 - **(c) Reliability — stochastic auditing.** The CLIs are flaky; don't fight it.
-  - ‖ PULL [V, `SD/011b8860`]: *"the audit barrage is stochastic—it doesn't have to be perfect
-    every time. As long as at least 1 audit is successfully executed, that should count...
-    Auditing as a practice should statistically yield better code."*
+  - ‖ PULL [V, `SD/011b8860`]: *"the audit barrage is stochastic—it doesn't have to be perfect every
+    time. As long as at least 1 audit is successfully executed, that should count... Auditing as a
+    practice should statistically yield better code."* (← the operator arguing at the population level
+    — the cleanest in-his-own-words statement of stochastic correctness.)
 
-## §7 — The bug that proves the thesis in the wild (AUDIT-01)
-- Strongest real-world "green tests missed it" anecdote. A flag change turned `--no-tailscale`
-  into a no-op and **silently inverted a security posture** — a no-auth studio quietly reachable
-  on the network. Tests stayed green; a **post-merge barrage caught it.** (`DEVELOPMENT-NOTES.md:13`,
+## §8 — The bug that proves the thesis in the wild (AUDIT-01)
+- Strongest real-world "green tests missed it" anecdote. A flag change turned `--no-tailscale` into a
+  no-op and **silently inverted a security posture** — a no-auth studio quietly reachable on the
+  network. Tests stayed green; a **post-merge barrage caught it.** (`DEVELOPMENT-NOTES.md:13`,
   `decompose-agent-discipline/audit-log.md:62`)
-- The line that frames severity: "a security-relevant behavior inversion, not just a cosmetic
-  flag rename." (This sets up the blast-radius idea in §8.)
+- The framing line: "a security-relevant behavior inversion, not just a cosmetic flag rename." (Sets
+  up blast-radius in §9.)
 
-## §8 — Act 3: governing the spec, not just the code (stack-control)
-- The barrage outgrows its origin plugin: **vendored in-house** (zero dw-lifecycle references),
-  then **single-sourced** behind one verb, `stackctl govern`.
-  - the consolidation story in one phrase: the audit logic had quietly forked into three
-    divergent bash scripts — the operator's name for it ‖ PULL [V, `845cf43c`]: *"nucleation
-    site of pathology."* (And the stale copy was the one actually running.)
-- **Extending left** — fire the barrage at *specifications* at definition time, before any code:
-  motivated by a manual spec barrage that found **51 findings, including 3 contradictions the
-  author had introduced.** ‖ PULL: *"Spec quality must not depend on a human remembering to run
-  the barrage."* (`spec.md`)
-- **The blast-radius rubric** — the answer to "what even *is* a HIGH," to stop phantom
-  nitpick-HIGHs: rate by *what happens if this ships as written*, including an agent building
-  **unattended** from a spec with no human to catch a wrong reading.
+## §9 — Act 3: governing the spec, not just the code (stack-control)
+- The barrage outgrows its origin plugin: **vendored in-house** (zero dw-lifecycle references), then
+  **single-sourced** behind one verb, `stackctl govern`.
+  - ‖ PULL [V, `845cf43c`]: the duplicated audit logic was a *"nucleation site of pathology"* (and
+    the stale copy was the one actually running).
+- **Extending left** — fire the barrage at *specifications* at definition time: motivated by a manual
+  spec barrage that found **51 findings, including 3 contradictions the author had introduced.**
+  ‖ PULL: *"Spec quality must not depend on a human remembering to run the barrage."* (`spec.md`)
+- **The blast-radius rubric** — the answer to "what even *is* a HIGH," to kill phantom nitpick-HIGHs:
+  rate by *what happens if this ships as written*, including an agent building **unattended** from a
+  spec with no human to catch a wrong reading.
   - ‖ PULL [prompt]: *"Calibrate by consequence, not by alarm."* (`audit-barrage-prompt.md`)
   - Field test: 5/5 genuine cross-model HIGHs, 0 phantom. (`0c388aea`)
-- ⚠️ writer note: the branch is `feature/stack-control` but internals still say
-  `feature/pluggable-lifecycle-providers` — same work; don't get thrown.
+- ⚠️ writer note: branch is `feature/stack-control` but internals say `feature/pluggable-lifecycle-
+  providers` — same work.
 
-## §9 — The recursive payoff (the thematic close-setup)
-- The barrage audited **its own spec** — and triggered a *"fiction cascade"*: round after round,
-  the fixes specified machinery the code never had, and the barrage kept attacking that fiction.
-  The cure: read the actual code, delete the invented mechanisms. (`5791b346`)
-- The punchline: the thing that finally made it converge was **DRY** — the spec had re-derived
-  the convergence rule in ~6 drifting places; collapsing it to one canonical statement was "the
-  actual convergence fix." (`65e2936d`, `0c388aea`)
-- The image to land on: *the auditor built to catch contradictions kept finding them in its own
-  description of itself — until the description stopped repeating itself.*
+## §10 — The recursive payoff (the thematic close-setup)
+- The barrage audited **its own spec** — and triggered a *"fiction cascade"*: round after round, the
+  fixes specified machinery the code never had, and the barrage kept attacking that fiction. Cure:
+  read the actual code, delete the invented mechanisms. (`5791b346`)
+- Punchline: the thing that finally made it converge was **DRY** — the spec re-derived the
+  convergence rule in ~6 drifting places; collapsing it to one canonical statement was "the actual
+  convergence fix." (`65e2936d`, `0c388aea`)
+- Land on: *the auditor built to catch contradictions kept finding them in its own description of
+  itself — until the description stopped repeating itself.*
 
-## §10 — Close: back to the first run
+## §11 — Close: back to the first run
 - Bookend §0: the tool's first act was finding bugs in itself; its hardest later battle was
-  contradictions in its own spec. It is, fundamentally, a machine for **not trusting one model
-  and a green checkmark.**
-- Return to the sibling frame: the toddlers lie; this is how you stop taking their word for it —
-  not by trusting harder, but by making a *different* mind look, every single time, whether
-  anyone remembers to ask or not.
-- ‖ PULL candidate for the kicker [V, `SD/011b8860`]: *"If you miss something, the audit will
-  catch it. If you break something, that's worse than doing nothing."*
+  contradictions in its own spec. It is, fundamentally, a machine for **not trusting one model and a
+  green checkmark.**
+- Return to the sibling frame: the toddlers lie; this is how you stop taking their word for it — not
+  by trusting harder, but by making a *different* mind look, every single time, whether anyone
+  remembers to ask or not. (One clean evolution bookend allowed here — then stop.)
+- ‖ PULL kicker candidate [V, `SD/011b8860`]: *"If you miss something, the audit will catch it. If
+  you break something, that's worse than doing nothing."*
+- The one allowed nod to the end result, in the operator's own modest voice: it turned out to be *"the
+  most effective tool we've built so far."* — but the point of the piece is that it was **found, not
+  designed**; nobody set out to build it. Close on the *process*, not the product.
 
 ---
 
 ## Open structural calls
-1. **Hook depth (§0):** lead on the self-audit paradox (current pick) vs. lead on the operator's
-   hand-Codex habit (§1). Self-audit is the stronger image; §1 is the stronger *why*. Current:
-   open on §0, pay the why immediately in §1.
-2. **Mechanics altitude (§3):** how much plumbing? Keep it to the two-verbs + parallel + run-dir
-   + CLI-not-API; push everything else to a footnote or cut. Risk: §3 turning into a manual.
-3. ~~**One arc or two?**~~ **RESOLVED (operator, 2026-06-07): single long post (§0–§10).** The
-   full arc stays in one piece — the recursive "fiction cascade → DRY" ending (§9) is the kicker
-   and is worth the length. Draft §8–§9 at full weight, not compressed.
-4. **AUDIT-01 placement:** standalone §7 (current) vs. folded into §4 as a second proof point.
-   Standalone keeps the "real-world, post-merge, security" punch distinct from the dogfood.
-5. **Numbers discipline:** only the figures in `research.md` "Numbers & receipts." No invented
-   precision/perf stats.
-6. ~~**Evolution-motif dosage**~~ **RESOLVED (operator, 2026-06-07): LIGHT** — cold-open + a single
-   closing bookend; no biology labels threaded through the body. "stochastic correctness" (literal
-   term) may recur freely; the *metaphor* stays out of the body. Respect file 05's strain points —
-   don't imply convergence *proves* correctness; keep it artificial/directed, and reach the
-   "intelligent variation / hybrid" concession early.
+1. ~~**Hook depth**~~ **RESOLVED:** open on the evolution frame (§0), then the real documented origin
+   (§1 bake-off → §2 MESA II → §3 make-it-routine). The self-audit-paradox image moved to §5 proof.
+2. **Origin depth (§1–§2):** how many paragraphs for bake-off + MESA II before "make it routine"?
+   Both are published — lean on links, pull quotes, ~2–4 paragraphs each. Risk: re-recapping two
+   whole posts and burying the barrage. Lean lean.
+3. ~~**One arc or two?**~~ **RESOLVED: single long post.** Full arc; the fiction-cascade→DRY ending
+   (§10) is the kicker.
+4. **Mechanics altitude (§4):** keep to two-verbs + parallel + run-dir + CLI-not-API; push the rest
+   to a footnote or cut. Risk: §4 turning into a manual.
+5. **AUDIT-01 placement:** standalone §8 (current) vs. folded into §5 as a second proof point.
+   Standalone keeps the real-world/security punch distinct from the dogfood.
+6. **Numbers discipline:** only figures in `research.md` "Numbers & receipts." No invented stats.
+7. ~~**Evolution-motif dosage**~~ **RESOLVED: LIGHT** — cold-open + one closing bookend; no biology
+   labels in the body. "stochastic correctness" (literal) may recur. Respect file 05's strain points.
 
 ## Iteration log
-- v1 (2026-06-07) — initial 11-section spine (§0–§10) from `research.md`'s three-act structure;
-  front-loaded the self-audit hook; mapped pull quotes; 5 open structural calls. Biggest
-  unresolved: call #3 (single post vs. sequel at §7).
-- v2 (2026-06-07) — call #3 RESOLVED: single long post, full arc §0–§10, §8–§9 at full weight.
-- v3 (2026-06-07) — **reframed §0 to the EVOLUTION cold-open** (diversity + selective pressure;
-  directed evolution + monoculture), per `research-raw/05`. Self-audit-paradox image moved from hook
-  to §4 proof. N-version/Knight-Leveson demoted to a passing aside. Motif threaded into §1
-  (monoculture) and §2 (diversity payoff). New open call #6 below.
-- v4 (2026-06-07) — operator notes folded: lead §0 on **deep time** (millennia of selective breeding,
-  not a software trick); add **"stochastic correctness"** as the thesis term introduced at the §0
-  turn; add the **hybrid / intelligent-variation** honest beat; **call #6 RESOLVED = LIGHT** dosage
-  (de-threaded §1/§2 tags to glancing callbacks); recorded approved lede voice/register. File 05
-  updated to match.
+- v1 (2026-06-07) — initial 11-section spine (§0–§10) from `research.md`; self-audit hook; 5 calls.
+- v2 (2026-06-07) — call #3 RESOLVED: single long post.
+- v3 (2026-06-07) — reframed §0 to the EVOLUTION cold-open; self-audit image → proof; N-version
+  demoted; motif threaded (later pulled back).
+- v4 (2026-06-07) — deep-time lead; **stochastic correctness** thesis term; hybrid honest beat;
+  call #6 RESOLVED = LIGHT dosage; recorded lede voice.
+- v5 (2026-06-07) — **integrated the real, documented ORIGIN STORY** (`research-raw/06`): new §1
+  bake-off (#252, different failure modes) + §2 MESA II (#315, cooperative falsification → first
+  stochastic correctness) + §3 "make it routine"; folded old "habit/genetic-diversity" sections into
+  §3; merged old mechanics into §4; **renumbered §0–§11** and fixed all cross-refs. Hook-depth call
+  RESOLVED; added origin-depth call #2 (lean on the published posts, don't re-recap).
+- v6 (2026-06-07) — **added the governing NARRATIVE PRINCIPLE: discovery process > finished tool**
+  (operator). Detective story, not product tour — weight the discovery/surprise beats, starve the
+  feature tour; "most effective tool" line used once, modestly, at the close. Rhymes with the
+  discover-don't-design frame.

--- a/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/research.md
+++ b/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/research.md
@@ -1,0 +1,352 @@
+---
+title: "Research — The Audit Barrage, Wired Into Every Task"
+status: research-complete
+gathered: 2026-06-07
+sources:
+  - scrapbook/research-raw/01-origin-dw-lifecycle.md   # dw-lifecycle / scope-discovery origin
+  - scrapbook/research-raw/02-stack-control-evolution.md # feature/stack-control evolution
+  - scrapbook/research-raw/03-transcript-narrative.md    # Claude Code session transcripts (the human "why")
+repos:
+  - /Users/orion/work/deskwork (branch main — origin; branch feature/stack-control — current)
+---
+
+# Research: why and how the audit barrage was built
+
+This is the narrative research note for the post. It synthesizes three raw receipts files
+(linked in frontmatter, kept in `scrapbook/research-raw/`). Every claim below traces to one of
+them, and through them to a commit hash, file path, issue number, or verbatim session quote.
+Where a number is contested between sources, the discrepancy is flagged — do not paper over it.
+
+---
+
+## Logline
+
+A solo operator kept finding bugs his test suite missed — but only when he hand-ran a *second*
+model (Codex) over work the first model (Claude) had already self-audited and called clean. That
+manual habit didn't scale, because it depended on his own inconsistent discipline. So he
+automated it: fire several different model-family CLIs in parallel at the same diff, capture
+everything, and treat their disagreements as signal. The very first run of the tool audited
+*itself* and found 13 real bugs a fully-green 1,966-test suite had let through. From there it grew
+teeth — wired unconditionally into the end of every task, taught to converge instead of nitpick
+forever, and finally pushed "left" to audit specifications before a line of code is written.
+
+---
+
+## The story spine (three acts)
+
+**Act 1 — The pain (dw-lifecycle / scope-discovery).** One model auditing its own work shares its
+own blind spots. The cure already existed — a different model family — but it cost the scarcest
+resource, operator attention. Automate it: "genetic diversity in failure modes."
+
+**Act 2 — The proof and the teeth (still dw-lifecycle).** The first barrage dogfoods the barrage
+and finds 13 novel bugs. Then it stops being a button you remember to press and becomes an
+unconditional end-of-task hook — which forces three new problems into the open: cost, convergence,
+and reliability. Each gets an answer (flat-rate CLIs; the dampener + slush pile; "1 successful
+audit counts").
+
+**Act 3 — Governing the spec (stack-control).** The barrage is vendored into a new plugin,
+single-sourced behind `stackctl govern`, and pointed at *specifications* at definition time. A
+recursive twist: the barrage audits its own spec, triggers a "fiction cascade" of fixes for
+machinery that never existed, and the real cure turns out to be DRY — collapsing duplicated prose
+to one canonical statement. A new "blast-radius" severity rubric teaches it to rate findings by
+consequence, not by alarm.
+
+---
+
+## ACT 1 — Why it was built
+
+### The originating moment (best opening scene)
+
+The whole feature is born in a single operator message. He was *already* running a Codex audit by
+hand, on top of the in-loop self-audit, and had noticed Codex caught what Claude missed:
+
+> "I currently run a codex audit by hand, in addition to the self-audit that happens in /dwi. The
+> codex audit usually finds stuff that claud misses. I'd like to explore options for automating a
+> battery of llm audit jobs using different models so a) we get genetic diversity in our audit
+> protocol; b) we run more audits out of band so the implementation team doesn't have to bear so
+> much of the weight of auditing... c) automating the audit barrage so the quality of the audit
+> isn't subject to my inconsistent discipline"
+> — operator, session `SD/2b49c58f` (03-transcript-narrative.md)
+
+That one message contains all three motives the post should name: **genetic diversity**,
+**out-of-band auditing**, and **removing inconsistent human discipline as the bottleneck**.
+
+### The founding insight, stated two ways
+
+- The model that wrote the code shares the blind spots that produced the bug. In-band self-audit
+  is "same model + same context... blind to its own failure modes." (`ROADMAP.md:76`, SKILL.md:153
+  — 01-origin)
+- The thing that *did* catch those bugs — a different model family, run by hand — "demonstrably
+  finds what Claude misses, but it requires manual invocation... Manual discipline doesn't scale."
+  (`ROADMAP.md:80` — 01-origin). The binding constraint is **operator attention, "the scarcest
+  resource."** (assistant cost/signal table, `SD/2b49c58f` — 03-transcript)
+
+### "Genetic diversity" is the operator's own phrase
+
+Worth stating plainly in the post: the central metaphor was coined by the operator, not retrofitted
+by marketing. Different training corpora fail differently; run several independently and the
+intersection of their complaints is high-signal. The barrage prompt encodes it: "The cross-model
+genetic diversity comes from each of you reporting independently." (`audit-barrage-prompt.md:6` —
+01-origin)
+
+### The trigger event (for a "how it started" beat)
+
+The feature was spun up as Phase 12 of "scope-discovery," parent issue **#353**, itself triggered by
+canary **#349** — a dogfood-feedback report that named the manual codex audit as an
+operator-attention cost the protocol couldn't absorb at scale. (01-origin, Key commits & issues)
+
+---
+
+## ACT 2 — The proof, and growing teeth
+
+### The proof: the barrage dogfoods itself (the centerpiece anecdote)
+
+The first audit-barrage run audited the audit-barrage feature's own code. Canonical record:
+`scope-discovery/audit-log.md` § "2026-05-29 — Phase 12 audit-barrage self-dogfood" (01-origin).
+
+- **13 distinct findings** across the 2 models that completed (gemini failed on quota).
+- **4 had cross-model agreement** — claude and codex independently flagged the same bug — making
+  them HIGH-confidence.
+- **All 13 would have shipped.** "1966/1966 tests passed; tsc clean; live 3-CLI round-trip returned
+  PROBE-OK." "All 13... were NOVEL — not caught by tsc, tests, or the dispatch-wrapper's response
+  validation." (`audit-log.md:349,520`)
+
+The headline four (good concrete detail — pick one or two for the post):
+- **Silent stdout truncation** — the orchestrator settled on the `exit` event, dropping in-flight
+  output on the one load-bearing path. claude found it via event-semantics; codex via a
+  stream-race. (AUDIT-20260529-01)
+- **A prompt renderer that was exported but never wired in** — `--prompt-file` was read raw; the
+  "project-overridable prompt template" acceptance criterion was only half-met. (AUDIT-20260529-04)
+
+> ⚠️ **Accuracy flag for the writer.** The ROADMAP/SKILL summarize this run as "4 cross-model + 7
+> single-model." The canonical audit-log says **4 cross-model + 9 single-model = 13**. Use the
+> audit-log's **13 / 4** as authoritative; if you cite "7," cite it as the ROADMAP's rounding and
+> move on. (01-origin, "Note on the count discrepancy")
+
+A second, sharper dogfood beat for color — the barrage caught a bug in its own tooling *before any
+model fired* (the renderer's unsubstituted-var check was over-eager), and later told the operator
+that one of his fixes (AUDIT-39) didn't actually satisfy the finding it claimed to close.
+(03-transcript, Surprises)
+
+### Teeth: from a button to an unconditional hook
+
+The decisive escalation — the operator did not want auditing to be a matter of judgment:
+
+> "when to run the barrage should not be a matter of policy and the agent should have no discretion.
+> It must be mechanized with teeth"
+> — operator, `SD/011b8860` (03-transcript)
+
+> "Audit findings are failures of the previous implementation that shouldn't be treated like
+> exceptions—they are guardrails to point the implementation team back to the happy path"
+> — operator, `SD/011b8860`
+
+This is the why behind wiring the barrage into the *end of every task* (the post's title beat). And
+the deeper why behind *that* is the autonomy thesis:
+
+> "what I'm trying to enable is a fully autonomous implementation loop that is self regulating and
+> self-correcting. Ultimately, I want to be able to point an orchestrator agent at a workplan, fire
+> off /dwi, then come back when the entire workplan is fully implemented, fully tested, and fully
+> audited"
+> — operator, `SD/011b8860`
+
+### Problem the hook forced #1 — Cost (the load-bearing design choice)
+
+Firing on every task only works if firing is free at the margin. Hence CLIs, not APIs:
+
+> "we won't be using model apis—we'll be using claude, codex, and gemini clis, since they are usage
+> based, not token based."
+> — operator, `SD/2b49c58f` (03-transcript)
+
+"A barrage on a multi-thousand-line diff is the same operator cost as a one-line probe... This is
+the load-bearing design choice that lets the end-of-task hook fire unconditionally at every task
+boundary." (SKILL.md:12 — 01-origin). This is also what makes the long-term arc (auto-fire,
+eventually a continuous daemon) economically possible at all. (Design A/B/C, `ROADMAP.md` — 01-origin)
+
+### Problem the hook forced #2 — Convergence (the dampener + the slush pile)
+
+An always-on auditor never shuts up. The operator named the fix from lived experience:
+
+> "We definitely need a dampener. From experience, an auditor agent will always find *something* to
+> complain about. I'm happy with two consecutive audits with 0 HIGH findings—we can keep the
+> nitpicks in a slush pile"
+> — operator, `SD/011b8860` (03-transcript)
+
+Both "dampener" and "slush pile" are the operator's coinages. The observed convergence pattern that
+motivated it (great structure for a paragraph): "First few iterations: real bugs caught. Middle
+iterations: critiques of fixes. Steady state: nitpicks on the audit-process itself." (assistant,
+`SD/011b8860` — 03-transcript)
+
+### Problem the hook forced #3 — Reliability (stochastic auditing)
+
+The CLIs are flaky (one session saw a ~50% 3-of-3 outage rate). Rather than fight it, the operator
+reframed the guarantee statistically:
+
+> "the audit barrage is stochastic—it doesn't have to be perfect every time. As long as at least 1
+> audit is successfully executed, that should count as a successful audit barrage. Auditing as a
+> practice should statistically yield better code"
+> — operator, `SD/011b8860` (03-transcript)
+
+### The real-world bug that vindicates it (AUDIT-01)
+
+Strongest "this caught something a green suite missed" anecdote. In a different feature, a change
+turned `--no-tailscale` into a deprecated no-op — which silently **inverted the security posture**
+for anyone who used that flag to keep a no-auth studio off the tailnet. Tests stayed green. A
+post-merge barrage caught it (AUDIT-01); the fix added a loud security-explicit notice. "a
+security-relevant behavior inversion, not just a cosmetic flag rename." (`DEVELOPMENT-NOTES.md:13`,
+`decompose-agent-discipline/audit-log.md:62` — 01-origin)
+
+---
+
+## ACT 3 — Governing the spec (stack-control)
+
+The barrage moves into a new plugin, `stack-control`, built on the thesis "invest heavily in
+up-front design and tooling; industrialize execution." (02-stack-control). Four moves matter:
+
+### 1. Vendored in-house
+
+The barrage was copied out of dw-lifecycle with **zero remaining references** ("no import, no
+shell-out, no requires"), because "dw-lifecycle is being deprecated and is NOT an allowed
+dependency." The vendoring commit fired a live native barrage that lifted 5 findings (including a
+BLOCKING contradiction) and correctly gated. (`d003312e` — 02-stack-control)
+
+### 2. Single-sourced behind `stackctl govern`
+
+The audit-protocol orchestration had quietly forked into **three divergent bash scripts** — and the
+stale copy still shelling the supposedly-removed dw-lifecycle dependency was the one the live hook
+actually ran. The operator called the duplication the **"nucleation site of pathology."**
+Consolidating into one TS subcommand (`stackctl govern --mode <implement|spec>`) shrank the scripts
+(235→47 and 141→36 lines) and, notably, **gave the implementation stage the full slush+gate it had
+been missing** — it had only been barraging and lifting. (`845cf43c`, `govern-consolidation-design.md`
+— 02-stack-control)
+
+> ⚠️ **Branch-name flag for the writer.** The work lives on `feature/stack-control`, but most
+> internal artifacts and commit trailers still say `feature/pluggable-lifecycle-providers` (the old
+> program name) — the spec dir, audit-log, and docs tree all carry the old name. Don't be thrown by
+> it; it's the same body of work. (02-stack-control, top note)
+
+### 3. Auditing specs, not just code ("extending left")
+
+The barrage now fires over a *specification* at definition time (`after_clarify`), because a manual
+barrage over an earlier spec had surfaced **51 findings, including 3 real contradictions the author
+had introduced.** "Spec quality must not depend on a human remembering to run the barrage."
+(`spec.md` — 02-stack-control). Confidence and severity were split into orthogonal axes so a
+single-model HIGH still blocks the gate.
+
+### 4. The "blast-radius" severity rubric
+
+The recurring failure was the barrage emitting a phantom precision-nit "HIGH" every round. The fix:
+rate each finding by **downstream blast-radius** — "the consequence if a downstream consumer acts on
+the audited surface *as written*," where the consumer "may be an adopter running the code, or —
+especially for a spec — an AI agent building **unattended** from it, with no human to catch a wrong
+reading." Mantra: **"Calibrate by consequence, not by alarm."** Field-tested 5/5 genuine
+cross-model HIGHs, 0 phantom. (`c1cf8de1`, `templates/audit-barrage-prompt.md`, `0c388aea` —
+02-stack-control)
+
+### The recursive twist + the best Act-3 story: the "fiction cascade"
+
+The barrage audited its own spec (the 004 self-hosting loop; ~20 lift sections, ~70 findings). For
+several rounds the *fixes kept specifying machinery the code never had* — cross-run reconciliation,
+disposition inheritance — and the barrage kept attacking that fiction. The cure was to read the
+actual code, delete the invented mechanisms, and align the spec to the as-built per-run protocol.
+(`5791b346` — 02-stack-control). It hardened into two encoded lessons: **fix the whole artifact, not
+just the cited span**, and **verify a mechanism exists in the code before you write it into the
+spec.**
+
+And the punchline of the whole convergence saga: the *actual* fix that made it converge was **DRY**.
+The spec had re-derived the convergence rule in ~6 prose locations that drifted out of sync; AUDIT-47
+collapsed it to one canonical statement ("The convergence condition is defined in exactly one
+place"). "the DRY-collapse of the duplicated convergence rule... was the actual convergence fix."
+(`65e2936d`, `0c388aea` — 02-stack-control). Good thematic close: the auditor designed to catch
+contradictions kept finding them in its own description of itself, until the description stopped
+repeating itself.
+
+---
+
+## Cast of concepts (glossary the post will lean on)
+
+| Term | One-liner | Source |
+|---|---|---|
+| **Audit barrage** | Fire N model-family CLIs in parallel at one diff/spec; capture all stdout; treat cross-model agreement as high-confidence. | 01, 02 |
+| **Genetic diversity** | Different training corpora = independent failure modes. Operator's coinage. | 03 |
+| **Three audit surfaces** | in-band self-audit + SDD two-reviewer + cross-model barrage (additive, not replacements). *See caveat below.* | 01 |
+| **The dampener** | Stop the loop when it converges: single clean run (0 HIGH + 0 MED) OR two consecutive 0-HIGH runs. | 02, 03 |
+| **Slush pile** | Residual MED/LOW flipped to `acknowledged-slush-pile-<date>` once the dampener engages. HIGHs are *never* slushed. | 02, 03 |
+| **Blast-radius rubric** | Rate severity by what happens if it ships as-written, not by how alarming it feels. | 02 |
+| **`stackctl govern`** | The single-sourced verb running render→barrage→lift→slush→gate for both spec and impl. | 02 |
+| **Fiction cascade** | Fixes specifying machinery the code never had; cured by verifying premise against code. | 02 |
+
+> ⚠️ **"Three surfaces" caveat.** The original framing is three additive surfaces. The live
+> trajectory is collapsing toward two: the SDD review cycle is being retired in favor of the barrage
+> (issue #387, open). If the post leans on "third independent surface," note that it's becoming the
+> *primary* surface. (01-origin)
+
+---
+
+## Pull-quote shortlist (all verbatim operator unless marked)
+
+1. "The codex audit usually finds stuff that claud misses." — `SD/2b49c58f`
+2. "automating the audit barrage so the quality of the audit isn't subject to my inconsistent
+   discipline" — `SD/2b49c58f`
+3. "we won't be using model apis—we'll be using claude, codex, and gemini clis, since they are usage
+   based, not token based." — `SD/2b49c58f`
+4. "It must be mechanized with teeth" — `SD/011b8860`
+5. "an auditor agent will always find *something* to complain about." — `SD/011b8860`
+6. "the audit barrage is stochastic—it doesn't have to be perfect every time." — `SD/011b8860`
+7. "Audit findings... are guardrails to point the implementation team back to the happy path"
+   — `SD/011b8860`
+8. "If you miss something, the audit will catch it. If you break something, that's worse than doing
+   nothing." — `SD/011b8860`
+9. (assistant) "First few iterations: real bugs caught. Middle iterations: critiques of fixes.
+   Steady state: nitpicks on the audit-process itself." — `SD/011b8860`
+10. (prompt) "Calibrate by consequence, not by alarm." — `templates/audit-barrage-prompt.md`
+
+---
+
+## Numbers & receipts (verified; cite exactly)
+
+- **13 findings / 4 cross-model / all would have shipped**, against a green 1,966-test suite —
+  Phase 12 self-dogfood (`audit-log.md:349,520`). *(ROADMAP rounds the split to "4+7"; audit-log's
+  4+9=13 is authoritative.)*
+- Per-model on that run: claude 195s / ~13.5KB / 9 findings; codex 28s / ~3.4KB / 4 findings; gemini
+  failed on quota. (`audit-log.md:353`)
+- **51 findings** (incl. 3 author-introduced contradictions) from a manual spec barrage — the
+  motivating evidence for spec-governance. (`spec.md`)
+- **Blast-radius rubric: 5/5 genuine cross-model HIGHs, 0 phantom** on field test. (`0c388aea`)
+- Single-sourcing shrank the bash scripts **235→47** and **141→36** lines; vitest **58→79**.
+  (`845cf43c`)
+- Dampener defaults: **2** consecutive 0-HIGH runs; iteration ceiling **5**. (`check-barrage-dampener.ts`)
+- ~300 lines of TS for the original Design A implementation. (`ROADMAP.md:123`)
+- gemini was disabled in practice after failing **94.1%** of runs (16 of 17) in one cycle.
+  (`audit-barrage-config.yaml`)
+
+⚠️ **Do not fabricate.** Every number above is quoted from source in the raw files. Don't invent
+performance/precision stats; if a claim isn't in the receipts, leave it out.
+
+---
+
+## Suggested angles / open questions for the draft
+
+- **Frame:** the post's title is "wired into every task" — the strongest spine is *why* you'd dare
+  wire an unconditional auditor into every task, and what three problems that dare forces you to
+  solve (cost, convergence, reliability). Act 2 is built for this.
+- **The human throughline:** this is one operator automating his own good habit because the habit
+  didn't scale. Keep him in it — the quotes carry the piece.
+- **The recursive payoff:** the tool's first act was finding 13 bugs in itself; its hardest later
+  battle was finding contradictions in its own spec. Open and close on self-audit.
+- **NOT FOUND (don't invent):** no transcript debates the *word* "barrage"; no single dramatic
+  "green tests passed but model X found Y" war story beyond AUDIT-01 and the dogfood instances. The
+  pain is a *pattern*, not one incident — write it that way. (03-transcript, "Explicitly NOT FOUND")
+
+---
+
+## Where the receipts live
+
+- `scrapbook/research-raw/01-origin-dw-lifecycle.md` — origin, mechanics, Phase 12 dogfood, Design
+  A/B/C, AUDIT-01, all with file/commit/issue cites.
+- `scrapbook/research-raw/02-stack-control-evolution.md` — vendoring, `stackctl govern`, dampener
+  internals, blast-radius rubric, fiction cascade, DRY-collapse, full commit timeline.
+- `scrapbook/research-raw/03-transcript-narrative.md` — verbatim operator quotes with session
+  citations; the human "why."
+- Primary repo: `/Users/orion/work/deskwork` — `ROADMAP.md`, `DEVELOPMENT-NOTES.md`, the
+  `audit-barrage` skill + src on `main`; `plugins/stack-control` + `specs/004-spec-governance` on
+  `feature/stack-control`.

--- a/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/research.md
+++ b/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/research.md
@@ -268,6 +268,7 @@ repeating itself.
 |---|---|---|
 | **Audit barrage** | Fire N model-family CLIs in parallel at one diff/spec; capture all stdout; treat cross-model agreement as high-confidence. | 01, 02 |
 | **Genetic diversity** | Different training corpora = independent failure modes. Operator's coinage. | 03 |
+| **Stochastic correctness** | Correctness as a statistical, population-level property of diversity + selection + iteration — not a per-run guarantee. The thesis term; the trade you make when you stop designing reliability into the generator. | 03, 05 |
 | **Three audit surfaces** | in-band self-audit + SDD two-reviewer + cross-model barrage (additive, not replacements). *See caveat below.* | 01 |
 | **The dampener** | Stop the loop when it converges: single clean run (0 HIGH + 0 MED) OR two consecutive 0-HIGH runs. | 02, 03 |
 | **Slush pile** | Residual MED/LOW flipped to `acknowledged-slush-pile-<date>` once the dampener engages. HIGHs are *never* slushed. | 02, 03 |

--- a/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/scrapbook/research-raw/01-origin-dw-lifecycle.md
+++ b/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/scrapbook/research-raw/01-origin-dw-lifecycle.md
@@ -1,0 +1,449 @@
+# Origin research: audit-barrage in dw-lifecycle / scope-discovery
+
+Scope of this document: the dw-lifecycle / scope-discovery ORIGIN of the audit-barrage
+feature only. (The later stack-control work is covered by a separate research note.)
+
+All claims are sourced to a file path, commit hash, or issue number in
+`/Users/orion/work/deskwork` (branch `main`). Lines tagged **[INFERENCE]** are my reading,
+not a direct quote. Everything else is verified from source.
+
+---
+
+## Why it was built (the founding insight / pain)
+
+The audit-barrage exists to answer a specific, demonstrated failure of the project's
+existing audit posture: **a green test suite is weak evidence that the code is correct.**
+
+The canonical statement of the pain is in `ROADMAP.md` § "Audit-barrage feature shape"
+(lines 70–80). The project already had a three-layer audit posture:
+
+| Layer | Cost | Signal |
+|---|---|---|
+| Self-audit via the `/dw-lifecycle:implement` orchestrator loop | Token budget on current task | Lower — "same model + same context blind to its own failure modes" |
+| Two-reviewer SDD cycle (spec + quality) | Sub-agent dispatch tokens | Medium-high |
+| Manual codex audit (operator-run) | **Operator attention** | **High — "different model finds what Claude misses"** |
+
+> "The operator-attention cost is the binding constraint. The codex audit demonstrably
+> finds what Claude misses, but it requires manual invocation, manual copy-paste, manual
+> finding-by-finding triage. Manual discipline doesn't scale. Automation removes the
+> discipline dependency."
+> — `ROADMAP.md:80`
+
+So the founding pain is two-headed:
+1. **A single model in a single context is blind to its own failure modes.** The model
+   that wrote the code (or one in the same family / same context) shares the blind spots
+   that produced the bug. (`ROADMAP.md:76`; SKILL.md:153 — in-band self-audit is
+   "Same-context blind to its own failure modes.")
+2. **The thing that actually caught those bugs — a different model family, run by hand —
+   depended on operator discipline, which doesn't scale.** (`ROADMAP.md:78-80`)
+
+The triggering event is named explicitly: the feature was "Triggered by canary
+[#349](https://github.com/audiocontrol-org/deskwork/issues/349) §2 framing of the
+manually-run codex audit as an operator-attention cost the protocol can't absorb at
+scale" (issue #353 body, the parent issue). Issue #349 is the dogfood-feedback report from
+driving the graphical-entries feature through the tooling; it framed the manual codex
+audit as an attention cost.
+
+The animating idea is **"genetic diversity in failure modes"**: different model families
+have different training corpora, so they fail differently. Running several independently
+against the same work surfaces bugs no single one would catch. (`ROADMAP.md:21`,
+`ROADMAP.md:68`; SKILL.md:155 — "Different training corpora = independent failure modes.")
+
+The prompt template itself encodes this: each CLI is told it is an **independent** reviewer,
+NOT collaborating — "The cross-model genetic diversity comes from each of you reporting
+independently." (`plugins/dw-lifecycle/templates/audit-barrage-prompt.md:3-6`)
+
+---
+
+## The three audit surfaces
+
+The barrage is framed as the **third independent audit surface**, additive — it does NOT
+replace the other two. (`ROADMAP.md:21`, SKILL.md:149-157)
+
+1. **In-band self-audit** — same model + same context (the orchestrator-loop pattern in
+   `plugins/dw-lifecycle/src/scope-discovery/orchestrator-loop/`). Catches obvious
+   correctness slips; same-context blind to its own failure modes. (SKILL.md:153)
+2. **SDD two-reviewer cycle** — `/dw-lifecycle:review` / `:audit`. Sub-agent dispatch
+   (`feature-dev:code-reviewer` runs spec-compliance + quality passes). Different context
+   from the implementer, but same model class. Medium signal. (SKILL.md:154)
+3. **Audit-barrage** — multiple model families in parallel. Different training corpora =
+   independent failure modes. "Highest signal for the bugs single-model audits miss."
+   (SKILL.md:155, `ROADMAP.md:21`)
+
+> "The three are additive — the barrage does NOT replace the other two; it adds genetic
+> diversity in failure modes." — `ROADMAP.md:21`
+
+**Caveat on surface #2 (verified):** the SDD two-reviewer cycle is being *retired* in favor
+of the barrage, under issue [#387](https://github.com/audiocontrol-org/deskwork/issues/387)
+(OPEN as of research). The audit-barrage SKILL.md (lines 10) notes the SDD cycle "is being
+retired under #387 and is no longer named to keep the prose internally consistent with the
+deleted review-discipline rule." Operator's verbatim framing in #387: *"the review skill is
+no longer hooked into the iterate cycle — superseded by the audit barrage hook. Review is no
+longer operationally enforced ... we should consider retiring review and audit in favor of
+audit barrage."* So the "three surfaces" framing is the original design; the live trajectory
+is collapsing toward two (in-band + barrage).
+
+---
+
+## How it works (mechanics, plainly)
+
+Two CLI verbs, intentionally split so the operator can inspect/tune the rendered prompt
+before it burns model budget. (SKILL.md:22-24, `ROADMAP.md:25-26`)
+
+### Verb 1: `dw-lifecycle audit-barrage-render` (pure prompt rendering)
+
+- Inputs: a template + a flat vars JSON → a rendered audit prompt.
+- Vars JSON has five keys (mirrors `EXPECTED_VARS` in `prompt-renderer.ts`):
+  `feature_slug`, `workplan_summary`, `diff`, `audit_log_excerpt`, `commit_subjects`.
+  (SKILL.md:28-38)
+- Template resolution: project override at
+  `.dw-lifecycle/scope-discovery/audit-barrage-prompt.md` takes precedence; falls back to
+  the plugin default at `plugins/dw-lifecycle/templates/audit-barrage-prompt.md`.
+  (SKILL.md:51, `ROADMAP.md:25`)
+- Each var is substituted at exactly ONE site — a 60 KB diff appears once, not tripled.
+  (SKILL.md:40; this was a fix — see AUDIT-20260529-11 below.)
+- Exit codes: 0 render OK; 1 render failed (missing declared var / malformed template /
+  surviving EXPECTED_VARS marker); 2 usage error. (SKILL.md:53-56)
+
+### Verb 2: `dw-lifecycle audit-barrage` (parallel CLI fan-out)
+
+1. Loads the model battery from `.dw-lifecycle/scope-discovery/audit-barrage-config.yaml`
+   (if present + `models:` uncommented); else the plugin default. (SKILL.md:91)
+2. Optionally filters to a subset via `--models claude,codex`. (SKILL.md:92)
+3. **Spawns each configured CLI in parallel** via `Promise.all` — no early exit; a failing
+   model does NOT abort siblings. (`orchestrate-barrage.ts:110-112` + header comment lines
+   1-22)
+4. Captures, per model: stdout → `<run-dir>/<model>.md`, stderr →
+   `<run-dir>/stderr/<model>.txt`. (SKILL.md:93, `orchestrate-barrage.ts:100-108`)
+5. Writes `<run-dir>/PROMPT.md` (rendered prompt verbatim) and `<run-dir>/INDEX.md`
+   (per-model exit code / duration / byte counts). (SKILL.md:94)
+6. Emits a `BarrageRun` JSON record to stdout; one-line summary to stderr. (SKILL.md:95)
+
+The CLIs invoked are **installed CLI binaries, not model APIs**: `claude -p "<prompt>"`,
+`codex exec "<prompt>"`, `gemini -p "<prompt>"`. (`ROADMAP.md:101-106`, SKILL.md:12)
+
+**Run-dir layout** (SKILL.md:136-145):
+```
+.dw-lifecycle/scope-discovery/audit-runs/<YYYYMMDDTHHMMSSsssZ>-<feature-slug>/
+├── INDEX.md          — per-model run manifest (triage starting point)
+├── PROMPT.md         — rendered audit prompt (verbatim)
+├── <model>.md        — captured stdout, per configured model
+└── stderr/
+    └── <model>.txt   — captured stderr, per configured model
+```
+Timestamp is millisecond-resolution so two barrages for the same feature in the same
+wall-clock second land in distinct dirs (SKILL.md:97) — this precision was itself a fix
+(AUDIT-20260529-07). The run dir is **permanent**: "the dogfood signal is preserved as
+evidence ... the verb itself never deletes a run dir." (SKILL.md:147)
+
+**Per-model exit/health contract:** verb exits 0 if at least one model produced
+positive-byte stdout and wasn't a spawn failure; non-zero CLI exits and timeouts fall on
+the healthy side because captured stdout is still triagable. Exit 1 = every model failed;
+exit 2 = usage error. (SKILL.md:99-102) Spawn failure (ENOENT — CLI not installed / not on
+PATH) returns `exitCode: -2` and is surfaced in INDEX without aborting siblings.
+(`spawn-cli.ts:15-17`)
+
+**Subprocess fine print (from `spawn-cli.ts`):** settle fires on `child.on('close')` not
+`'exit'` so stdio pipes fully drain before the byte-count snapshot (header lines 33-40);
+on timeout it sends SIGTERM then SIGKILL after a 5s grace (`SIGKILL_GRACE_MS = 5000`,
+line 48); the prompt is delivered via stdin when the args template uses `{{prompt-stdin}}`,
+which bypasses the OS ARG_MAX limit (`spawn-cli.ts:146-191`, the E2BIG fix — see issue #386).
+
+### The triage / lift-into-audit-log workflow
+
+The firing is automated; the triage is human. (`ROADMAP.md:111`) Steps (SKILL.md:114-124):
+1. Read `<run-dir>/INDEX.md` — spot-check exit codes, byte counts, timeouts, spawn errors.
+2. Read each `<run-dir>/<model>.md` — captured stdout of one CLI's audit, in the prompt's
+   finding-block format (`Finding-ID: AUDIT-BARRAGE-<model>-NN`, severity, surface, body).
+3. **Cross-reference across models.** Findings two-or-more models flagged independently are
+   cross-model agreement = HIGH-confidence. Combined into one canonical entry with both
+   Finding-IDs in the header (e.g.
+   `AUDIT-20260529-04 (claude-prompt-renderer-orphaned + codex-prompt-seed-override; cross-model)`).
+4. **Lift findings into the feature's `audit-log.md`** — each gets a stable
+   `AUDIT-<YYYYMMDD>-NN` ID + `Status: open` + fix guidance. Single-model findings are
+   lifted too. This is the same closure workflow `/dw-lifecycle:audit` / `:review` use; the
+   barrage just adds one more raw input. (SKILL.md:124)
+
+The downstream closure machinery (Phase 13 "Design A.5", `ROADMAP.md:125-140`): once a
+finding is `open`, `/dw-lifecycle:promote-findings` scopes it into the workplan as a
+TDD-first task; an implement-loop gate refuses task pickup while any open finding exists;
+`apply-audit-flips` flips `open → fixed-<sha>` from `Closes AUDIT-<id>` commits;
+`close-shipped-audit-findings` / `/dw-lifecycle:re-audit-fixed-findings` flip
+`fixed-<sha> → verified-<date>`. `re-audit-fixed-findings` fires a fresh barrage and checks
+whether each fixed finding still surfaces — re-surfacing = "did-not-actually-fix."
+(`plugins/dw-lifecycle/skills/re-audit-fixed-findings/SKILL.md`)
+
+### Why CLIs and not APIs (load-bearing design choice)
+
+`ROADMAP.md:82-88` gives three reasons; SKILL.md:12 reinforces:
+1. **Usage-based pricing vs flat-rate CLI.** "Running a broad audit barrage against API
+   endpoints accrues meaningful per-call cost. The CLIs are flat-rate." (`ROADMAP.md:86`)
+   SKILL.md:12: "A barrage on a multi-thousand-line diff is the same operator cost as a
+   one-line probe: zero direct API metering, bounded by the per-CLI subscription. This is
+   the load-bearing design choice that lets the `/dw-lifecycle:implement` end-of-task hook
+   fire unconditionally at every task boundary."
+2. **Auth already configured** — no API-key handling/rotation; the operator's existing CLI
+   setup is the auth surface. (`ROADMAP.md:87`)
+3. **Subprocess orchestration is a well-trodden path** — the plugin already shells out to
+   `gh`, `git`, `npx tsx`, `jscpd`; adding `claude`/`codex`/`gemini` is the same pattern.
+   (`ROADMAP.md:88`)
+
+---
+
+## Phase 12 self-dogfood (the proof)
+
+The single most important evidence point. The first audit-barrage run audited the
+audit-barrage feature itself (its own Tasks 1-3). Canonical record:
+`docs/1.0/001-IN-PROGRESS/scope-discovery/audit-log.md` § "2026-05-29 — Phase 12
+audit-barrage self-dogfood" (lines 347-533).
+
+**Headline numbers (audit-log.md:349, 522):**
+- **13 distinct findings** across 2 successful models.
+- **4 with cross-model agreement** (both claude and codex independently found the same bug)
+  = HIGH-confidence.
+- **9 single-model findings** (claude-only) + the 4 cross-model = 13 total.
+- **ALL 13 would have shipped without the audit.** "1966/1966 tests passed; tsc clean; live
+  3-CLI round-trip returned PROBE-OK." (audit-log.md:349)
+- audit-log.md:520: "All 13 audit-barrage findings above were NOVEL — not caught by tsc,
+  tests, or the dispatch-wrapper's response validation."
+
+> **Note on the count discrepancy (verified):** the ROADMAP and the audit-barrage SKILL.md
+> summarize this as **"4 cross-model HIGH-confidence findings + 7 single-model findings"**
+> (`ROADMAP.md:32`, `DEVELOPMENT-NOTES.md` "Recently shipped"). The canonical audit-log says
+> **4 cross-model + 9 single-model = 13** (audit-log.md:349, 522). The audit-log breaks the
+> single-model bucket into claude-only code findings (AUDIT-...-05..09, five entries, one of
+> which is informational) plus two operator-side in-band findings (AUDIT-...-10, -11). The
+> "7" figure in the ROADMAP appears to count a narrower slice. **Use the audit-log's
+> 4 + 9 = 13 as authoritative; cite the ROADMAP's "4 + 7" only with this caveat.**
+> [INFERENCE on the reconciliation; both raw numbers are quoted verbatim from source.]
+
+**Per-model run stats (audit-log.md:353):**
+- claude: 195s, 13,495 stdout bytes, 8 findings + 1 framing finding.
+- codex: 28s, 3,379 bytes, 4 findings.
+- gemini: FAILED — exit 1, "exhausted capacity on this model" (operator-level quota; not an
+  audit-barrage bug). So the barrage was effectively a 2/3 fleet.
+
+**The four cross-model HIGH-confidence findings (the headline four):**
+- **AUDIT-20260529-01** — Exit-vs-close event truncation. `spawnCliAgainstModel` settled on
+  `'exit'`, dropping in-flight stdout chunks (silent data-fidelity loss on the load-bearing
+  path). claude found it from the event-semantics angle; codex independently from the
+  stream-error-race angle. (audit-log.md:357-370) Severity HIGH.
+- **AUDIT-20260529-02** — args_template validation vs spawn-cli substitution drift. A config
+  like `args_template: "--prompt={{prompt}}"` passed validation but the CLI never received
+  the rendered prompt → silent empty-output run. Both models independently flagged the exact
+  failure mode. (audit-log.md:372-385) Severity HIGH.
+- **AUDIT-20260529-03** — Exit-code contract drift: code, `types.ts` comment, and PRD each
+  said something different about when a run is "healthy." (audit-log.md:387-398) Severity
+  MEDIUM.
+- **AUDIT-20260529-04** — The prompt-renderer was exported but **not wired into the verb at
+  all**; `--prompt-file` was read raw. The Phase 12 "project-overridable prompt template"
+  acceptance criterion was only half-met. Fix: wired the renderer via the new sibling verb
+  `audit-barrage-render`. claude + codex cross-model + in-band Finding-001. (audit-log.md:400-415)
+  Severity HIGH.
+
+**Notable single-model finding:** AUDIT-20260529-05 — a ~305s timeout timer leaked on the
+spawn-error path; "fires on nearly every real run for any audit-barrage adopter who hasn't
+yet installed all configured models" (audit-log.md:430). Severity HIGH, claude-only.
+
+**Closure:** all 11 lifted findings carry `Status: fixed-08971e4` (commit `08971e4`), or
+`informational` (AUDIT-20260529-09). (audit-log.md:529-531)
+
+**Why this is the proof:** the acceptance signal was "≥1 finding the in-band self-audit +
+SDD review cycle didn't catch." The audit-log calls it "**Met overwhelmingly**"
+(audit-log.md:349; ROADMAP:32 "Acceptance signal met overwhelmingly"). The feature's very
+first act was to find 13 real bugs in itself that a fully-green 1966-test suite missed.
+
+---
+
+## Design A / B / C arc
+
+Source: `ROADMAP.md` § "Audit-barrage feature shape" (lines 64-162). The family's goal:
+> "replace the operator's manually-run codex audit with an automated battery that fires
+> multiple LLMs against the same work, gives genetic diversity in failure modes, runs
+> out-of-band so the implementation team focuses on features, and removes the audit-quality
+> dependency on operator discipline." — `ROADMAP.md:68`
+
+- **Design A — operator-triggered audit-barrage skill (SHIPPED).** The verb pair
+  `audit-barrage-render` → `audit-barrage`; shipped as **Phase 12 of scope-discovery**,
+  parent issue [#353](https://github.com/audiocontrol-org/deskwork/issues/353) (CLOSED).
+  Operator triggers; triage is human. v1 model battery: Claude family (baseline / same class
+  as in-band), OpenAI Codex CLI (the operator's manual baseline — "demonstrably catches what
+  Claude misses"), Google Gemini CLI (third independent training corpus, "closes the
+  diversity gap"). Project-config YAML lets adopters add/remove models without code changes.
+  Cost: "~300 lines of TS + tests + the prompt template + the SKILL.md." (`ROADMAP.md:90-123`)
+
+- **Design A.5 — Phase 13 anti-deferral discipline + closure triad (SHIPPED).** Pairs
+  structurally with A: where A *produces* findings, A.5 ensures every open finding is worked
+  to completion without manual status-flip discipline (promote-findings, the
+  check-open-findings implement gate with no bypass flag, TDD commit-msg gate,
+  apply-audit-flips, close-shipped-audit-findings, re-audit-fixed-findings).
+  (`ROADMAP.md:125-140`) Operator anchor: *"Filing a bug report isn't good enough. It MUST
+  BE SCOPED INTO THE WORKPLAN ... A broken implementation is not done — it's broken."*
+  (`ROADMAP.md:138`)
+
+- **Design B — lifecycle-triggered automation + meta-audit (NEXT).** Composes over A's
+  primitives. Adds (a) **auto-fire at lifecycle waypoints** (`session-end`, `complete`,
+  `/release` Pause 5 — no explicit operator invocation) and (b) a **meta-audit synthesizer**:
+  a single extra LLM CLI call against the N raw runs that ranks findings by
+  confidence × actionability, de-duplicates, flags cross-model agreement, and emits one
+  structured findings block. High-confidence cross-model convergence (M of N models) gets
+  auto-promoted to the audit-log as `Status: pending-operator-review`. The operator's review
+  surface "collapses from 'three raw audit files per session' to 'one meta-audit summary per
+  release.'" (`ROADMAP.md:142-154`)
+  - **Note:** parts of Design B's auto-fire appear to have landed already — the "Autonomous
+    implementation loop" section lists an "End-of-task audit-barrage hook (Phase 15 T4)"
+    that "Auto-fires after every commit" and "Phase 16 (#383, shipped) — Audit-barrage always
+    fires on new diff." (`ROADMAP.md:177, 183-185`) [INFERENCE: the A→B boundary blurred in
+    practice as the implement-hook landed; the ROADMAP still labels full Design B "NEXT."]
+
+- **Design C — continuous background audit daemon (exploratory).** A long-running process
+  watching for new commits, firing audit jobs continuously in the background; runs accumulate
+  with no operator action; the orchestrator-loop reads them per-turn. "Most ambitious.
+  Highest cost (continuous-audit run-rate). Highest decoupling." Committed to "only after
+  Design A + B prove the model-diversity payoff justifies the always-on cost."
+  (`ROADMAP.md:156-162`)
+
+The pricing tradeoff (`ROADMAP.md:82-88`) is what gates the arc: because the CLIs are
+flat-rate (not metered per token), the barrage can fire unconditionally at every task
+boundary (Design B) and even continuously (Design C) without per-call cost — the same broad
+barrage against API endpoints "accrues meaningful per-call cost" and would NOT be affordable
+at that cadence. The flat-rate-CLI choice is what makes the always-on end-state economically
+possible.
+
+---
+
+## Key commits & issues
+
+**Commits (branch `main`):**
+- `a284fc35` — `feat(scope-discovery): audit-barrage + closure triad + /dwi dampener (Phase 12-15) (#376)` — the merge of the barrage + closure triad.
+- `08971e4` (full: see audit-log) — the Phase 12 self-dogfood fix commit; all 11 lifted findings flip to `fixed-08971e4`. (audit-log.md:529)
+- `e7f5b4df` — `fix(audit-barrage): catch E2BIG + flip default to {{prompt-stdin}}` (the #386/#397 ARG_MAX fix).
+- `740377e9` — `refactor(audit-barrage): extract reportSpawnError + migrate project override to {{prompt-stdin}}`.
+- `9fb4db0b` — `test(audit-barrage): pin bare {{prompt-stdin}} template strips to empty argv`.
+- Dogfood-barrage rounds (later phases, each surfacing more findings against the tooling itself):
+  `44c85d8d` round-2 (7 findings, "hook closes its own loop"), `553651b1` round-3 (3),
+  `bfed2e2b` round-4 (5, "all critiquing round-3 fixes"), `9acdc406` round-5 (2,
+  "convergence resumed 5 → 2"), `51910c80` round-7 (5, "including recursive regression").
+- AUDIT-01 story commits (see below): `c4d7ada2` (introduced the inversion), `a8c98c6d`
+  (the fix), `52bc9f0c` (flip AUDIT-01..05 to fixed).
+
+**Issues:**
+- [#353](https://github.com/audiocontrol-org/deskwork/issues/353) — parent: "scope-discovery
+  Phase 12: multi-model audit barrage (Design A per ROADMAP)" (CLOSED). Triggered by canary
+  #349 §2.
+- [#349](https://github.com/audiocontrol-org/deskwork/issues/349) — the canary dogfood-feedback
+  report that framed the manual codex audit as an unscalable operator-attention cost.
+- [#386](https://github.com/audiocontrol-org/deskwork/issues/386) — "audit-barrage spawn E2BIG
+  on large diffs." Surfaced 2026-06-01 during a graphical-entries Phase 8 autonomous burndown;
+  "the session hit this 6+ times in succession — every implement-hook fire after Step 8.1.2
+  onward returned `spawn E2BIG`" because the accumulated diff from a long autonomous `/dwi`
+  run exceeded OS ARG_MAX. Fix: deliver the prompt over child stdin (`{{prompt-stdin}}`)
+  instead of argv. (issue #386 body; `spawn-cli.ts:146-191`; classifier
+  `classifyE2BIGSpawnError` at `spawn-cli.ts:58-66`.)
+- [#387](https://github.com/audiocontrol-org/deskwork/issues/387) — "Retire /dw-lifecycle:review
+  + /dw-lifecycle:audit in favor of audit-barrage" (OPEN). The barrage has become the project's
+  primary review/audit mechanism; the SDD cycle is "no longer operationally enforced."
+- [#392](https://github.com/audiocontrol-org/deskwork/issues/392) — "promote-findings: TDD-first
+  task shape is unsatisfiable for non-code findings" (OPEN). The end-of-task hook's
+  `promote-findings --auto` stamps a uniform TDD-first shape (failing test + `npx vitest run
+  ... exits 0`) onto every finding, which can't be satisfied for comment/docs/config findings.
+
+### The AUDIT-01 story (post-merge barrage catches what the green suite missed)
+
+This is the strongest single anecdote of the barrage catching a real, security-relevant bug
+that a passing test suite let through. From `DEVELOPMENT-NOTES.md:13` and
+`docs/1.0/003-COMPLETE/decompose-agent-discipline/audit-log.md:55-95`:
+
+- In the `decompose-agent-discipline` feature, commit `c4d7ada2` changed `--no-tailscale`
+  from "force loopback-only" into a **deprecated no-op** (with a `DESKWORK_STUDIO_NO_TAILSCALE`
+  env hatch). The motivating failure was real: operators stranded off-keyboard.
+- But the change **silently inverted the security posture** for the *reverse* user class: an
+  adopter who scripted `deskwork-studio --no-tailscale` specifically to keep the **no-auth**
+  studio off the tailnet now got Tailscale auto-detection and tailnet exposure — "with only a
+  stderr line as notice." Because the studio has no auth and Tailscale is a trusted-network
+  bind, "this is a security-relevant behavior inversion, not just a cosmetic flag rename."
+  (audit-log.md:62)
+- The project's own flag-stability rule is about *exit-code* stability; here the exit code was
+  preserved but "the *security posture* the flag was protecting is reversed." (audit-log.md:64)
+- **The green test suite missed it.** A **post-merge audit-barrage** surfaced it (AUDIT-01),
+  and the fix landed in `a8c98c6d`: "loud security-explicit --no-tailscale notice" that warns
+  the no-auth studio is now tailnet-reachable and names the loopback-only restore path; plus
+  AUDIT-04 normalized env-var truthiness (`=1/true/yes/on`, case-insensitive, trimmed; warns on
+  unrecognized values instead of silently failing open). (commit `a8c98c6d` message;
+  audit-log.md:95)
+- `DEVELOPMENT-NOTES.md:13`: "Post-merge audit-barrage surfaced + fixed a security-posture
+  inversion in the `--no-tailscale` change (AUDIT-01) that the green test suite missed." This
+  entry also spun off #387 and #392.
+
+---
+
+## Quotable facts & numbers (citable)
+
+- **13 findings, 4 cross-model, all would have shipped.** First audit-barrage run (against
+  the barrage itself, Phase 12) surfaced 13 distinct findings across 2 successful models, 4
+  with cross-model agreement; "ALL of these would have shipped without this audit (1966/1966
+  tests passed; tsc clean; live 3-CLI round-trip returned PROBE-OK)." —
+  `docs/1.0/001-IN-PROGRESS/scope-discovery/audit-log.md:349`.
+- **"4 cross-model HIGH-confidence + 7 single-model"** is the ROADMAP/SKILL summary of the same
+  run — `ROADMAP.md:32`. (Reconcile against the audit-log's 4 + 9 = 13; see caveat above.)
+- **All findings NOVEL.** "All 13 audit-barrage findings above were NOVEL — not caught by tsc,
+  tests, or the dispatch-wrapper's response validation." — `audit-log.md:520`.
+- **Per-model run:** claude 195s / 13,495 bytes / 9 findings; codex 28s / 3,379 bytes / 4
+  findings; gemini failed (quota). — `audit-log.md:353`.
+- **The binding constraint is operator attention.** "The operator-attention cost is the
+  binding constraint. The codex audit demonstrably finds what Claude misses, but it requires
+  manual invocation ... Manual discipline doesn't scale." — `ROADMAP.md:80`.
+- **Genetic diversity in failure modes.** The three layers "are additive — the barrage does
+  NOT replace the other two; it adds genetic diversity in failure modes." — `ROADMAP.md:21`.
+  Prompt: "The cross-model genetic diversity comes from each of you reporting independently."
+  — `templates/audit-barrage-prompt.md:6`.
+- **Same-context blindness.** In-band self-audit is "Same model + same context. ...
+  Same-context blind to its own failure modes." — `SKILL.md:153`.
+- **CLI, not API — the load-bearing choice.** "A barrage on a multi-thousand-line diff is the
+  same operator cost as a one-line probe: zero direct API metering ... This is the load-bearing
+  design choice that lets the `/dw-lifecycle:implement` end-of-task hook fire unconditionally
+  at every task boundary." — `SKILL.md:12`. Pricing rationale: "Running a broad audit barrage
+  against API endpoints accrues meaningful per-call cost. The CLIs are flat-rate." —
+  `ROADMAP.md:86`.
+- **~300 lines.** "The implementation is small (~300 lines of TS + tests + the prompt template
+  + the SKILL.md)." — `ROADMAP.md:123`. (Source dir actually present:
+  `config-loader.ts`, `orchestrate-barrage.ts`, `prompt-renderer.ts`, `run-artifacts.ts`,
+  `spawn-cli.ts`, `types.ts`.)
+- **Parallel, no early exit.** "Fire every model in parallel via `Promise.all`. No early exit:
+  a failing model does not abort siblings." — `orchestrate-barrage.ts:10-13`.
+- **Spawn-failure code -2.** "Spawn failure (ENOENT, etc.) returns `exitCode: -2` ... The
+  orchestrator surfaces the failure in the INDEX without aborting siblings." —
+  `spawn-cli.ts:15-17`.
+- **Run dir is permanent.** "The run dir is permanent — the dogfood signal is preserved as
+  evidence ... the verb itself never deletes a run dir." — `SKILL.md:147`.
+- **E2BIG real-world hit.** "the session hit this 6+ times in succession — every implement-hook
+  fire after Step 8.1.2 onward returned `spawn E2BIG`." — issue #386 body.
+- **AUDIT-01 security inversion.** "Post-merge audit-barrage surfaced + fixed a security-posture
+  inversion in the `--no-tailscale` change (AUDIT-01) that the green test suite missed." —
+  `DEVELOPMENT-NOTES.md:13`; "a security-relevant behavior inversion, not just a cosmetic flag
+  rename." — `decompose-agent-discipline/audit-log.md:62`.
+- **Anti-deferral anchor.** "Filing a bug report isn't good enough. It MUST BE SCOPED INTO THE
+  WORKPLAN ... A broken implementation is not done — it's broken." — operator, `ROADMAP.md:138`.
+- **Model battery v1:** Claude (baseline), OpenAI Codex CLI ("demonstrably catches what Claude
+  misses"), Google Gemini CLI ("third family with independent training corpus; closes the
+  diversity gap"). — `ROADMAP.md:115-117`.
+- **Gemini disabled in practice.** Project config override disabled gemini effective 2026-06-01
+  — "gemini-cli was failing 94.1% of runs (16 of 17 across the graphical-entries Phase 0 audit
+  cycle)" on JSON-routing failures + quota errors; the battery "was effectively a 2/3 fleet
+  (claude + codex) in practice." — `.dw-lifecycle/scope-discovery/audit-barrage-config.yaml:6-15`.
+
+---
+
+## Source index
+
+- `/Users/orion/work/deskwork/ROADMAP.md` (§ "Recently shipped — Audit-barrage"; § "Audit-barrage feature shape"; § "Autonomous implementation loop")
+- `/Users/orion/work/deskwork/DEVELOPMENT-NOTES.md:13`
+- `/Users/orion/work/deskwork/plugins/dw-lifecycle/skills/audit-barrage/SKILL.md`
+- `/Users/orion/work/deskwork/plugins/dw-lifecycle/skills/audit/SKILL.md`
+- `/Users/orion/work/deskwork/plugins/dw-lifecycle/skills/re-audit-fixed-findings/SKILL.md`
+- `/Users/orion/work/deskwork/plugins/dw-lifecycle/src/scope-discovery/audit-barrage/` (orchestrate-barrage.ts, spawn-cli.ts, + config-loader.ts, prompt-renderer.ts, run-artifacts.ts, types.ts)
+- `/Users/orion/work/deskwork/plugins/dw-lifecycle/templates/audit-barrage-prompt.md`
+- `/Users/orion/work/deskwork/.dw-lifecycle/scope-discovery/audit-barrage-config.yaml`
+- `/Users/orion/work/deskwork/docs/1.0/001-IN-PROGRESS/scope-discovery/audit-log.md:347-533` (Phase 12 self-dogfood)
+- `/Users/orion/work/deskwork/docs/1.0/003-COMPLETE/decompose-agent-discipline/audit-log.md:55-95` (AUDIT-01)
+- GitHub issues #353, #349, #386, #387, #392 (via `gh issue view`)

--- a/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/scrapbook/research-raw/02-stack-control-evolution.md
+++ b/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/scrapbook/research-raw/02-stack-control-evolution.md
@@ -1,0 +1,480 @@
+# Research raw: the audit-barrage's evolution in stack-control
+
+**Scope:** the `stack-control` plugin evolution only (the dw-lifecycle origin is covered by a
+separate research note). Source: `feature/stack-control` branch of `/Users/orion/work/deskwork`
+(read read-only via `git show` / `git log`). Every claim cites a commit hash or file path.
+Where a statement is inference rather than directly stated, it is tagged **[INFERENCE]**.
+
+Note on branch naming: the work lives on `feature/stack-control`, but most artifacts and commit
+trailers still say `feature/pluggable-lifecycle-providers` — that was the original program branch
+name; the rename to `feature/stack-control` happened late and several internal strings are stale
+(see TF-17 in `0c388aea`). The `004-spec-governance` spec dir, the audit-log, and the
+`docs/1.0/001-IN-PROGRESS/pluggable-lifecycle-providers/` docs tree all carry the old name.
+
+---
+
+## From dw-lifecycle to stack-control (what changed)
+
+stack-control is a NEW plugin (`plugins/stack-control/`) built around the thesis **"invest heavily
+in up-front design and tooling; industrialize execution"** (`96855cc4` docs: record the thesis).
+The audit-barrage that originated in dw-lifecycle was carried into this plugin and matured along
+four axes:
+
+1. **It was vendored in-house, severing the dw-lifecycle dependency.** Commit `d003312e`
+   (`feat(stack-control): vendor audit-barrage in-house — remove the dw-lifecycle dependency`,
+   `multi/migrate-audit-barrage`) did a structure-preserving copy of the barrage lib
+   (config-loader, orchestrate-barrage, prompt-renderer, spawn-cli, run-artifacts, types), the
+   convergence criterion (`check-barrage-dampener`), the extraction (`extract-barrage-findings`),
+   and 3 `stackctl` verbs (`audit-barrage-render` / `audit-barrage` / `audit-barrage-lift`).
+   Operator directive quoted in the commit: "dw-lifecycle is being deprecated and is NOT an allowed
+   dependency." Result: "ZERO dw-lifecycle references (no import, no shell-out, no requires)."
+   Re-namespaced override paths from dw-lifecycle → `.stack-control/audit-barrage-{config,prompt}`
+   and run-dir root → `.stack-control/audit-runs/` (32 string replacements). This commit
+   superseded AUDIT-20260607-10 and -12 (the deep-import coupling and the lift-test dependency).
+   The commit reports a LIVE native barrage firing `claude`, writing a run-dir, lifting 5 findings
+   (incl. a BLOCKING contradiction on a seeded fixture), and the gate returning `blocked`.
+
+2. **The barrage now governs SPECS, not just code** — see "Auditing specs, not just code" below.
+   Feature `004-spec-governance` (codename `design/spec-governance`) fires the barrage over a spec
+   at definition time. Source: `e849ad1e` (author spec via `/speckit-specify`) through the whole
+   004 chain.
+
+3. **`stackctl govern` single-sources the whole protocol** for both phases — see next section.
+
+4. **The convergence/dampener/slush protocol was ported and hardened** through a live
+   self-governing convergence loop — see "The convergence loop & dampener rules."
+
+The organizing principle is repeated across commits as **"detection over instruction"**: make the
+failure state (an ungoverned, self-contradictory spec) *mechanically surfaced* rather than relying
+on a human remembering to run the barrage (`specs/004-spec-governance/spec.md`, "Why this feature
+exists").
+
+---
+
+## stackctl govern (single-sourcing the protocol)
+
+**Design doc:** `docs/1.0/001-IN-PROGRESS/pluggable-lifecycle-providers/govern-consolidation-design.md`
+(committed `f5efadca`). It is explicit that this is "an implementation-task design, not a Spec Kit
+feature spec," driven by operator directive 2026-06-06: "rip out the duplication now."
+
+**The verified problem** (from the design doc): the audit-protocol *orchestration* was duplicated
+and divergent across three bash scripts:
+- `spec-governance/scripts/bash/govern-spec.sh` (235 lines): full protocol — render → barrage →
+  lift → **slush → gate**.
+- `deskwork-governance/scripts/bash/govern.sh` (141 lines): render → barrage → lift only. **No
+  slush, no gate.** Its comment literally said "mirror govern.sh lines 25-42."
+- `.specify/extensions/deskwork-governance/scripts/bash/govern.sh`: a STALE hand-copy that still
+  shelled `dw-lifecycle` (pre-vendoring) — **and it was the copy the live `after_implement` hook
+  actually ran**, so the "no dw-lifecycle dependency" achievement "is not live." The operator
+  called the duplication the "nucleation site of pathology" (`845cf43c`).
+
+**The fix:** commit `845cf43c` (`feat(govern): single-source the audit protocol in stackctl govern
+(both stages)`) created a new TS subcommand `stackctl govern --mode <implement|spec>`:
+- `src/subcommands/govern.ts` (arg parse + orchestration)
+- `src/govern/protocol.ts` (slug resolve, barrage-bin guard, render→barrage→lift→slush→gate,
+  verdict + exit code; dropped the `jq` dependency by assembling vars via `JSON.stringify`)
+- `src/govern/payload-implement.ts` (git diff + bounded untracked fold)
+- `src/govern/payload-spec.ts` (spec[+plan] fold, checkpoint defaulting)
+
+Key consequence stated in the commit: **both modes now run slush + the convergence gate. This GAVE
+the implementation stage the full protocol it previously lacked (it only barraged+lifted) — closing
+the spec/impl asymmetry.** The two bash scripts shrank to thin shims (141→36 and 235→47 lines) that
+`exec stackctl govern --mode <x>`. Per-stage difference is ONLY: the payload (mode), what `blocked`
+gates (spec = next-step graduation; implement = done-ness), and an implement-only clone-detection
+step. "Convergence criterion / finding state machine / slush / gate are identical." Verified vitest
+79/79 (up from 58).
+
+Related same-session work: `a38bfc6d` re-synced the stale `.specify` install + fixed repo-root shim
+resolution (the live regression); `dee24fbd`/`cce44dc6` fixed the clone detector to scan shell (not
+just TypeScript) and ignore `.specify`; `63c4466f` wired clone detection into the session lifecycle.
+The live regression "hid for ~2 days" (TF-16, `0fabe3f9` tooling-feedback) — the deeper class named
+is "mechanism exists but never fires."
+
+---
+
+## The convergence loop & dampener rules
+
+The protocol is a loop: **barrage → triage/fix the spec → re-barrage → … until convergence**
+(`specs/004-spec-governance/spec.md` FR-010). The mechanics, as implemented in
+`plugins/stack-control/src/scope-discovery/promote-findings/check-barrage-dampener.ts` and
+`slush-remaining.ts`:
+
+### The dampener — two ways to engage (the `(branch a) OR (branch b)` predicate)
+
+From `check-barrage-dampener.ts` (`checkBarrageDampener`), `dampened = consecutiveQuietEngages ||
+singleRunCleanEngages`:
+
+- **Branch (a) — single-run-clean** (the stiffer one): the MOST RECENT run has **0 open HIGH+ AND
+  0 open MEDIUM**. A single clean run engages immediately, no second run needed. Origin: operator
+  directive 2026-05-31, recorded in the source doc-comment.
+- **Branch (b) — N-consecutive-quiet** (the looser one): the last **N (default 2) consecutive**
+  recorded runs each have **0 open HIGH+** (high or blocking). Branch (b) does NOT itself require
+  0 MEDIUM. This is the **two-consecutive-0-HIGH window**.
+
+The branches are "intentionally asymmetric (it is the ported protocol)" (`spec.md` FR-010). An
+*iteration* is one recorded barrage run (one audit-log lift section). "Consecutive" = the last N
+recorded runs for that checkpoint, regardless of whether the spec text changed between them — an
+inter-iteration edit does NOT reset the count. "Two-consecutive-quiet is a **stability heuristic**,
+not a determinism proof." HIGH+ counted only when `Status: open` (dispositioned findings don't
+count) — a literal `Status:`-line scan, NOT similarity matching.
+
+The exact meaning of "dampener engaged" was itself a barrage finding: AUDIT-20260607-46 (`381d1267`,
+`fix(spec-004): disambiguate 'dampener engaged' = (branch a OR branch b)`). The third live barrage
+under the blast-radius rubric flagged a cross-model HIGH (8 sub-findings): FR-010 had overloaded the
+term — its gate condition treated it as (a OR b) while a definition sentence narrowed it to
+two-consecutive-only (b), making branch-(a) single-run graduation unreachable for an agent reading
+the definition. The fix verified the premise against the code (`slush-remaining.ts:236`,
+`spec-governance-gate.ts:208`, `check-barrage-dampener.ts:206` all key off `dampened = (a OR b)`)
+and disambiguated the spec to match. Notably the bug was **self-inflicted by the prior AUDIT-45 fix**.
+
+### The cross-run union gate (the SC-006 guarantee)
+
+Graduation requires **BOTH** the dampener engaged (per-run verdict) **AND** the cross-run blocking
+open-set empty. The second condition was added by AUDIT-20260607-45 (`5f649ceb`, `fix(govern): gate
+blocks on cross-run union of un-dispositioned HIGH/BLOCKING`). The second live barrage under the
+blast-radius rubric found a cross-model HIGH: the gate had counted only the most-recent run's open
+findings, but SC-006 promises a recorded-open HIGH blocks graduation until dispositioned — a HIGH
+surfaced in run N then stochastically NOT re-flagged in N+1/N+2 would let the gate graduate with
+run-N's HIGH still open (the "expected unattended-mode path"). Fix: `countOpenFindingsUnion()` in
+`check-barrage-dampener.ts` unions un-dispositioned HIGH/BLOCKING across ALL the checkpoint's
+recorded runs via the SAME literal-`Status:` parser (`findBarrageSections` + `countHighPlusInSection`)
+— deliberately NOT similarity matching, "so it does not reintroduce the deleted cross-run
+reconciliation fiction." The two-consecutive dampener verdict stays per-run; only the blocking
+open-set is unioned.
+
+### The dampener (slush) rules — slush vs promote; HIGHs never slushed
+
+`slush-remaining.ts` (`slushRemaining`) is the loop's terminator. Verbatim operator directive in
+the source doc-comment (Phase 15 closeout, 2026-05-31): *"We should address all of the auditors'
+findings, but when we've gone two consecutive audits with 0 high issues, we can bin the smaller
+items into the slush pile."*
+
+- Slush flips residual `Status: open` MEDIUM/LOW findings to
+  `acknowledged-slush-pile-<YYYY-MM-DD>` — a third disposition state, "acknowledged-as-not-fixed,"
+  distinct from `open` and `fixed-<sha>`.
+- **Slush REFUSES unless the dampener is engaged** (it returns `dampenerEngaged: false` and changes
+  nothing) — "slushing while the audit still surfaces real bugs would erase signal."
+- **HIGH/BLOCKING findings are NEVER slushed.** They are collected into `skippedHighs` and left
+  `Status: open`. A future barrage surfacing a HIGH resets the dampener; that HIGH re-surfaces as
+  next work. A HIGH clears only by a recorded `fixed-<sha>` or a recorded acknowledgment with a
+  substantive reason — never silently.
+- The slush step is **automatic and runs on every protocol pass, BEFORE the gate evaluates**: the
+  chain is **render → barrage → lift → slush → gate** (`spec.md` FR-015). It is a no-op until the
+  dampener engages, so an early noisy pass slushes nothing.
+
+### DRY-collapse as the real convergence fix (AUDIT-20260607-47)
+
+This is the standout "real fix" of the late convergence loop. Commit `65e2936d` (`fix(govern):
+slush all remaining MED/LOW at convergence + DRY-collapse convergence spec`). The commit names the
+ROOT CAUSE of findings 44/46/47: **"the spec re-derived the convergence/dampener/slush/union
+mechanic in ~6 prose locations that drifted out of sync (a DRY violation in spec prose)."** AUDIT-47
+specifically: FR-010's absolute "no open MEDIUM at graduation" contradicted SC-007's gating-run
+scoping, because the convergence slush only binned the most-recent run (Issue #380 `scope:'latest'`),
+leaving an EARLIER 0-HIGH run's MEDIUMs open at two-consecutive convergence.
+
+The fix had two halves:
+- **Code:** the protocol's convergence-time slush now passes `--scope all`, binning ALL still-open
+  MED/LOW across the engaged checkpoint's runs (confined to that checkpoint via `flipCheckpoint`,
+  FR-011). Operator's rule quoted: *"when either case obtains, slush any remaining."* HIGH/BLOCKING
+  still never slushed. (See the `AUDIT-20260607-47` comment block in `slush-remaining.ts`.)
+- **Spec (the DRY-collapse):** "convergence rule DRY-collapsed to a single canonical FR-010
+  statement; FR-007/FR-014/FR-015/SC-006/SC-007/AUDIT-03/Key-Entities now reference it instead of
+  re-deriving it. **The convergence condition is defined in exactly one place.**" FR-010 carries the
+  in-text marker: *"THE canonical convergence rule — every other mention in this spec references
+  here, none re-derives it."*
+
+The session-end commit `0c388aea` summarizes: "the DRY-collapse of the duplicated convergence rule
+(AUDIT-47) was **the actual convergence fix**." DRY-collapse of prose recurs as a real fix because
+the audit-barrage keeps attacking the drift between duplicated descriptions.
+
+### Bounded termination & override
+
+Convergence is over the most-recent recorded runs, so a clean barrage of a fixed spec converges via
+single-run-clean — "no fictional window-reset" (FR-014, `5791b346`). If convergence is not reached
+within the per-checkpoint iteration ceiling (**default 5**, configurable via `--ceiling` /
+`GOVERN_CEILING`), the system records a `non-converged` terminal state. Forward paths: a recorded
+`--override "<reason>"` (mandatory reason; no reason → no override), or fix-and-continue raising the
+ceiling. AUDIT-44 (`d4cad0e9`) reframed burn-down as out-of-loop manual remediation (a separate
+`slush-findings --burn-down` invocation, never wired into the protocol chain — `burnDownSlush()` in
+`slush-remaining.ts`). AUDIT-48 (override scope enforced-vs-warned) was left **open** at session end
+awaiting an operator fork decision (`1eb0d244`, `0c388aea`).
+
+Gate contract reference: `specs/004-spec-governance/contracts/convergence-gate.md` — verb
+`stackctl spec-governance-gate`, states `converged | blocked | non-converged | overridden`, exit
+codes 0 (converged/overridden) / 1 (blocked/non-converged) / 2 (fatal). Contract assertion #7
+demands **port fidelity**: the criterion result MUST match `check-barrage-dampener`'s engage
+decision on identical input — "the same function, not a hand-retyped approximation."
+
+---
+
+## Blast-radius severity rubric
+
+The biggest conceptual addition to the barrage *prompt* in stack-control. Before, severity was a
+code-oriented gloss (`high` for correctness bugs adopters hit; `medium` for design issues that
+compound; `low` for hygiene). The new rubric rates by **downstream blast-radius**.
+
+**Design doc:** `docs/superpowers/specs/2026-06-07-blast-radius-severity-calibration.md` ("Approach
+A — rubric rewrite"), created `eb524c0e`. It resolves the open protocol question "what IS a HIGH."
+Operator decision: **Approach A only** — rewrite the rubric in the plugin-default barrage prompt and
+field-test, adding a calibration pass (Approach B, a post-barrage re-rater) only if A proves
+insufficient. The edit targets the plugin DEFAULT
+(`plugins/stack-control/templates/audit-barrage-prompt.md`), not a project override, "since it's a
+general fix and the feature branch already isolates it from adopters."
+
+**Shipped:** commit `c1cf8de1` (`feat(audit-protocol): blast-radius severity rubric in the barrage
+prompt (Approach A)`). The rubric now in `templates/audit-barrage-prompt.md`:
+
+> **Severity — rate each finding by downstream blast-radius:** the consequence if a downstream
+> consumer acts on the audited surface *as written*. The consumer may be an adopter running the
+> code, or — especially for a spec — an AI agent building **unattended** from it, with no human to
+> catch a wrong reading. Rate by what would actually happen if this shipped as-is, **not by how
+> alarming the finding feels.**
+
+The five levels (vocabulary + lift-parser unchanged):
+- `blocking` — acting on it as-written breaks the feature's stated goals; OR (for a spec) the more
+  natural reading an agent reaches first is the wrong one, so it will likely be built wrong by
+  default.
+- `high` — a correctness/safety defect a consumer will hit; OR a spec contradiction/ambiguity where
+  the readings are roughly equally plausible and the artifact doesn't disambiguate.
+- `medium` — a design issue that compounds; OR a spec inconsistency a reasonable consumer would
+  resolve correctly anyway.
+- `low` — hygiene; cosmetic wording with no behavioral/implementation consequence.
+- `informational` — context worth seeing, not itself a defect.
+
+Key framing in the prompt: **"Calibrate by consequence, not by alarm."** A genuine contradiction a
+reader would obviously resolve correctly is at most `medium`; a quietly-plausible wrong reading an
+agent would actually build is `high`/`blocking` even if it looks minor. "A spec's internal
+consistency is load-bearing — it is the input to an unattended build." Every finding must state its
+blast-radius reasoning in the body, at every level.
+
+**Field-test outcome:** session-end `0c388aea` reports the rubric "passed its field test
+(**5/5 genuine cross-model HIGHs, 0 phantom**)." The design doc named a known limitation
+(max-severity aggregation: one panic-HIGH from one model nullifies A on that finding; that's
+Approach B's case). A documented meta-lesson from `845afbcc`: **"calibration cannot fix a
+false-premise HIGH; only verify-premise can"** — an iteration-3 HIGH was false-on-premise (the
+template has 1 criteria location; the doc had quoted the OLD rubric, making the rendered count
+appear as 3), de-quoted at the root so it couldn't recur.
+
+---
+
+## Auditing specs, not just code
+
+Feature `004-spec-governance` extends governance **left** — from after-implementation to
+definition-time. The motivating evidence (`spec.md`, "Why this feature exists"): a manual
+cross-model barrage over the `impl/execution-engine` spec (`specs/002`, claude + codex) surfaced
+**51 findings — including 3 real contradictions the author had introduced** plus deep design gaps a
+single authoring pass missed. "Spec quality must not depend on a human remembering to run the
+barrage."
+
+What changed conceptually for spec-auditing:
+- The barrage fires at **`after_clarify`** (the spec is decision-complete then), configurable to
+  also fire `after_plan`; `after_specify` is out of scope (a spec there may still carry intentional
+  unresolved placeholders). FR-011.
+- **Confidence vs severity were split into orthogonal axes** (AUDIT-01/-02, `8da8219c` round-2):
+  the gate counts SEVERITY only; cross-model agreement became a separate `cross-model-agreed |
+  single-model` annotation. A single-model HIGH-severity finding still blocks the gate. FR-003.
+- Spec-specific clustering caveat (FR-003): on single-file specs the path-token agreement branch
+  over-clusters (every finding cites the same `spec.md`), so the heading-substring branch (≥12-char
+  shared substring) is load-bearing — but it under-clusters when two models word the same finding
+  differently. Cross-model agreement on single-file specs is "best-effort in both directions"; a
+  single-model HIGH must not be deprioritized on the assumption it "would have clustered."
+
+**Spec-authoring discipline as a captured DEFINE-phase skill.** Commit `07855c8c`
+(`design(inbox): capture spec-authoring skill — DEFINE-phase 'how to write a spec'`) captured a
+future skill characterized as **"DRY prose, promises-before-mechanism, barrage-enforced."** The DRY
+violation in spec prose (AUDIT-47, above) is the direct evidence that spec-authoring needs the same
+DRY discipline as code. [INFERENCE] "promises-before-mechanism" describes writing the contract/SC
+before the machinery — consistent with the fiction-cascade lesson (specifying mechanism the code
+never had).
+
+**Govern delivers via a mandatory Spec Kit hook** (FR-012, AUDIT-09): the spec-governance extension
+fires universally whether the operator drives the front-door `define`/`extend` skills or raw
+`/speckit-*` commands — never folded into the front-door skills only. Mirrors the founding
+`deskwork-governance` `after_implement` extension.
+
+---
+
+## The recursive / self-dogfooding angle
+
+Two distinct recursive loops run in this work:
+
+**1. The barrage audits its OWN design spec (`004` self-hosting).** Commit `0a6465c5` (`T024
+dogfood — govern THIS spec via the new extension (self-hosting loop closed)`) governed the
+spec-governance spec with the spec-governance extension. The 004 audit-log
+(`docs/1.0/001-IN-PROGRESS/pluggable-lifecycle-providers/audit-log.md`) accumulated **20
+audit-barrage lift sections and ~70 AUDIT-NN findings** over the run. Findings carried
+`AUDIT-20260607-NN` IDs and `fixed-<hash>` disposition markers (e.g. `ca408983` disposition
+AUDIT-20260607-47 `fixed-65e2936d`; `0ca3edc5` → `fixed-381d1267`; `f5c70feb` → `fixed-5f649ceb`).
+The barrage found real contradictions sitting **inside its own spec** — the audit-log entry for the
+SC-004/FR-007 contradiction calls it "precisely the kind of author-introduced internal contradiction
+the feature exists to catch, now sitting inside its own spec."
+
+**2. The barrage audits the blast-radius DESIGN DOC before that design ships.** Before implementing
+the blast-radius rubric, the design doc itself was barraged across iterations and the findings folded
+back in:
+- `e727b779` fold in design-barrage findings (iter 1: 2 HIGH + 6 MED + 2 LOW)
+- `1e9520c2` fold in iteration-2 findings (iter 2: 0 HIGH, 1 MED, 1 LOW)
+- `845afbcc` converge (iter 2 + iter 3 = two-consecutive-0-HIGH → dampener engages → converged)
+
+So the design doc for the severity rubric was itself driven to convergence by the very protocol it
+was specifying.
+
+**The "fiction cascade" — the central recursive failure-and-recovery story.** Across rounds 3-5
+(roughly `5cfdb6a7` → `cb29ab7f` → `59e08262`), the barrage kept flagging the spec, and the fixes
+kept specifying **machinery that did not exist in the code**: AUDIT-31 cross-run reconciliation,
+AUDIT-39 severity-aware disposition inheritance, AUDIT-34 cross-checkpoint inheritance, AUDIT-33
+`GOVERN_NEW_ATTEMPT`. Commit `5791b346` (`spec(004): align protocol FRs to real per-run code —
+delete cross-run fiction`) diagnoses it precisely: *"each specified machinery that does not exist —
+and that fiction was the surface the barrage kept attacking (AUDIT-39, -40 both targeted it). The
+fresh-context dispatch cured fix-verbosity but kept faithfully specifying fictional mechanisms the
+findings demanded."* Reading the actual code (`check-barrage-dampener.ts`, `spec-governance-gate.ts`,
+`slush-remaining.ts`) showed the protocol is "purely PER-RUN" with NO cross-run matching. The fix
+deleted the fiction and aligned the spec to the as-built per-run protocol.
+
+This drove **two encoded governance lessons** (`7127a704`, `feat(governance): fix-dispatch
+discipline`):
+1. **WHOLE-ARTIFACT SCOPE** — fixing only the finding's cited span caused AUDIT-41 (FR-007 corrected
+   but SC-004 / a scenario / an edge case left contradicting it). Dispatch with the whole artifact
+   in scope; run a whole-artifact consistency sweep before re-barraging.
+2. **VERIFY THE PREMISE AGAINST THE CODE before specifying machinery** — "confirm a mechanism exists
+   in the code before writing it into the spec; when a finding's premise is false, align to as-built
+   + record a false-premise acknowledgment instead of inventing the mechanism."
+
+A third related lesson — **fresh-context fix dispatch** (`d2fa2c1e`): operator diagnosis was that
+"fix quality degrades under context fatigue, not auditor scope" — so each open finding is dispatched
+to a clean, minimal sub-agent context rather than hand-authored in the accumulated orchestrating
+context. Encoded into both governance skill bodies (`7127a704`).
+
+---
+
+## Chronological commit timeline
+
+(Most-recent last. Hashes from `git log main..feature/stack-control`. Dates from commit headers.)
+
+**Program framing / Spec Kit bootstrap (pre-004):**
+- `96855cc4` record the thesis — invest up front, industrialize execution.
+- `1480cb27` make governing the design process first-class in the protocol.
+- `156344d6` add design-inbox (low-friction out-of-sequence idea capture).
+- `5081326e` (002) reconcile-conflict handling — audit-barrage sanity gate.
+- Feature 1 (front door, `specs/003`): `48295090` scaffold → `1de44b18` US1 MVP (execute-check +
+  governance rehome) → governance-finding cycles AUDIT-20260605-01..12 → `afc3e64e` front door
+  COMPLETE (35/35).
+
+**Feature 004 spec-governance — Spec Kit chain:**
+- `e849ad1e` author spec via `/speckit-specify` (2026-06-06).
+- `02bda431` `/speckit-clarify` — resolve gate/hook/mechanism + **port the audit protocol**.
+- `2d6cd706` `/speckit-plan` — "compose dw-lifecycle barrage + port the protocol as a gate."
+- `63f4cb39` `/speckit-tasks` — 24 TDD-first tasks + convergence-gate phase.
+- `9ce058c2` `/speckit-implement` — spec-governance extension + convergence gate (US1/US2/US3 + gate).
+- `dcebffe6` empty-models-array crash fixed (dogfood-caught) + deterministic smoke.
+
+**004 self-hosting + the vendoring pull-forward:**
+- `0a6465c5` T024 dogfood — govern THIS spec (self-hosting loop closed).
+- `e8fa3139`/`45c10f90` after_implement governance findings AUDIT-20260607-10..15.
+- `d003312e` **vendor audit-barrage in-house — remove the dw-lifecycle dependency** (`multi/migrate-audit-barrage`).
+- `9fdb38b5` mark AUDIT-10/-12 fixed by the migration.
+
+**004 convergence loop — fiction cascade rounds (2026-06-06):**
+- `1a2f258c` encode the 9 dogfood governance findings into spec.md.
+- `701fad25` per-checkpoint convergence loops + outage fail-loud (AUDIT-05/-07).
+- `82283836` re-govern after_clarify — 0 HIGH (HIGHs resolved), 8 new MED/LOW (AUDIT-16..23).
+- `8da8219c` round-2 — confidence/severity split (AUDIT-16..23).
+- `37642683` **port the slush pile — terminate the convergence loop** (AUDIT-03 fidelity).
+- `5cfdb6a7` round-3 fixes (healthy-predicate contradiction, override scoping, etc.).
+- `d2fa2c1e` capture fresh-context fix dispatch (operator diagnosis: context fatigue).
+- `85bfb616` fix step runs in a fresh-context sub-agent, not the orchestrator.
+- `cb29ab7f` round-4 fixes AUDIT-31..38 via fresh-context dispatch.
+- `59e08262` AUDIT-39 severity-aware disposition inheritance (later deleted as fiction).
+- `64c84c8d` iteration-5 — AUDIT-40 (gate non-converged 5/5).
+- `5791b346` **align protocol FRs to real per-run code — delete cross-run fiction.**
+- `7127a704` fix-dispatch discipline — whole-artifact scope + verify-premise-vs-code.
+- `ce9e3228` full-spec consistency sweep vs the per-run model.
+- `1ee37265` iteration-7 — AUDIT-42 (fiction cascade cleared; new HIGH on health predicate).
+
+**Single-sourcing govern + clone-detector wiring (2026-06-07 early):**
+- `f5efadca` design for single-sourcing the protocol.
+- `845cf43c` **single-source the audit protocol in `stackctl govern` (both stages)** (vitest 58→79).
+- `a38bfc6d`/`dee24fbd`/`cce44dc6`/`63c4466f` clone-detector + stale `.specify` regression fixes.
+- `0fabe3f9` session end — audit-protocol reliability.
+
+**Blast-radius severity calibration (2026-06-07):**
+- `eb524c0e` design doc (Approach A — rubric rewrite).
+- `e727b779` fold design-barrage findings (iter 1).
+- `1e9520c2` fold iteration-2 findings.
+- `845afbcc` converge design doc (iter 2+3 two-consecutive-0-HIGH).
+- `c1cf8de1` **blast-radius severity rubric in the barrage prompt (Approach A)**.
+- `c2f70f76` backfill journal — audit-protocol reliability II.
+
+**Live convergence loop under the new rubric (2026-06-07, iters 9-13):**
+- `ce223ce5` AUDIT-42 — split barrage liftability from coverage (crash-after-banner ≠ clean).
+- `aa77929e` AUDIT-43 — graduation never carries open MEDIUM.
+- `d4cad0e9` AUDIT-44 — reframe burn-down as out-of-loop manual remediation.
+- `5f649ceb` **AUDIT-45 — gate blocks on cross-run union of un-dispositioned HIGH/BLOCKING.**
+- `381d1267` AUDIT-46 — disambiguate "dampener engaged" = (branch a OR branch b).
+- `65e2936d` **AUDIT-47 — slush all remaining MED/LOW at convergence + DRY-collapse convergence spec.**
+- `1eb0d244` run-13 lift — AUDIT-48 open (override scope enforced-vs-warned).
+- `07855c8c` capture spec-authoring skill (DRY prose, promises-before-mechanism, barrage-enforced).
+- `0c388aea` session end — blast-radius rubric field-tested 5/5 genuine; 4 HIGHs fixed; DRY-collapse
+  was the real fix; AUDIT-48 open.
+
+---
+
+## Quotable facts & numbers (citable)
+
+- The audit-barrage was **vendored out of dw-lifecycle into stack-control with ZERO dw-lifecycle
+  references** ("no import, no shell-out, no requires"). — `d003312e`
+- The vendoring commit fired a **live native barrage that lifted 5 findings including a BLOCKING
+  contradiction on a seeded fixture**, and the gate returned `blocked`. — `d003312e`
+- The duplicated bash orchestration was the operator-named **"nucleation site of pathology."** —
+  `845cf43c`; the design doc verified three divergent copies (235 ln, 141 ln, and a stale
+  dw-lifecycle-shelling install copy that "is the copy the live `after_implement` hook runs"). —
+  `govern-consolidation-design.md`
+- Single-sourcing into `stackctl govern` shrank the two bash scripts **141→36 and 235→47 lines** and
+  **gave the implementation stage the full slush+gate protocol it previously lacked** (it only
+  barraged + lifted). vitest **58→79**. — `845cf43c`
+- The motivating evidence for spec-governance: a manual barrage over the `specs/002` spec surfaced
+  **51 findings, including 3 real contradictions the author had introduced.** —
+  `specs/004-spec-governance/spec.md`
+- The dampener default threshold is **2 consecutive 0-HIGH runs**; the iteration ceiling default is
+  **5**. — `check-barrage-dampener.ts`, `spec.md` FR-014.
+- Dampener = `(branch a: single-run 0-HIGH AND 0-MEDIUM) OR (branch b: two-consecutive 0-HIGH)`. —
+  `check-barrage-dampener.ts`, AUDIT-46 (`381d1267`).
+- **HIGH/BLOCKING findings are NEVER slushed**; slush **refuses unless the dampener is engaged**. —
+  `slush-remaining.ts`.
+- Operator directive verbatim: *"We should address all of the auditors' findings, but when we've
+  gone two consecutive audits with 0 high issues, we can bin the smaller items into the slush
+  pile."* — `slush-remaining.ts` doc-comment (Phase 15 closeout, 2026-05-31).
+- The protocol pass order is **render → barrage → lift → slush → gate**, slush automatic-before-gate
+  on every pass. — `spec.md` FR-015, `845cf43c`.
+- The **"fiction cascade"**: rounds 3-5 fixes specified cross-run reconciliation / disposition
+  inheritance / `GOVERN_NEW_ATTEMPT` machinery **the code never had**; `5791b346` deleted it and
+  aligned the spec to the as-built per-run protocol. — `5791b346`, `1ee37265`.
+- The **blast-radius rubric field-tested 5/5 genuine cross-model HIGHs, 0 phantom.** — `0c388aea`.
+- Rubric mantra: **"Calibrate by consequence, not by alarm."** — `templates/audit-barrage-prompt.md`.
+- Blast-radius design-doc barrage iteration counts: iter 1 = 2 HIGH + 6 MED + 2 LOW; iter 2 = 0
+  HIGH, 1 MED, 1 LOW; iter 3 converged (two-consecutive-0-HIGH). — `1e9520c2`, `845afbcc`.
+- Meta-lesson: **"calibration cannot fix a false-premise HIGH; only verify-premise can."** —
+  `845afbcc`.
+- **DRY-collapse was the actual convergence fix:** the spec re-derived the convergence mechanic in
+  **~6 prose locations that drifted out of sync**; AUDIT-47 collapsed it so "the convergence
+  condition is defined in exactly one place." — `65e2936d`, `0c388aea`.
+- The 004 self-hosted audit-log accumulated **~20 barrage lift sections / ~70 AUDIT findings.** —
+  `audit-log.md` (counted on the branch).
+- Findings carry `AUDIT-20260607-NN` IDs and `fixed-<hash>` disposition markers (e.g. AUDIT-47 →
+  `fixed-65e2936d`). — `ca408983`, `0ca3edc5`, `f5c70feb`.
+- The barrage prompt itself instructs models to rate severity for **"an AI agent building
+  unattended from [a spec], with no human to catch a wrong reading."** —
+  `templates/audit-barrage-prompt.md`.
+
+---
+
+## Source index (files read on `feature/stack-control`)
+
+- `specs/004-spec-governance/spec.md` — the canonical FR-001..FR-015 / SC-001..SC-008 spec.
+- `specs/004-spec-governance/contracts/convergence-gate.md` — the gate verb contract.
+- `plugins/stack-control/templates/audit-barrage-prompt.md` — the barrage prompt + blast-radius rubric.
+- `plugins/stack-control/src/scope-discovery/promote-findings/check-barrage-dampener.ts` — dampener + cross-run union.
+- `plugins/stack-control/src/scope-discovery/promote-findings/slush-remaining.ts` — slush + burn-down.
+- `docs/1.0/001-IN-PROGRESS/pluggable-lifecycle-providers/govern-consolidation-design.md` — single-sourcing design.
+- `docs/superpowers/specs/2026-06-07-blast-radius-severity-calibration.md` — the blast-radius design doc (recursively barraged).
+- `docs/1.0/001-IN-PROGRESS/pluggable-lifecycle-providers/audit-log.md` — the 004 self-hosted findings log.

--- a/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/scrapbook/research-raw/03-transcript-narrative.md
+++ b/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/scrapbook/research-raw/03-transcript-narrative.md
@@ -1,0 +1,366 @@
+# Audit-Barrage — Transcript Narrative (Raw Research)
+
+Mined from Claude Code session transcripts (JSONL) in three deskwork project dirs:
+`scope-discovery` (where Design A was built), `stack-control` (the `stackctl govern`
+convergence work), and `design-control` (where the barrage was used/refined on a
+design-heavy product). All quotes below are **verbatim** operator (USER) text or
+assistant text actually present in the transcripts, with the source session filename
+cited. Nothing here is invented; assistant lines are flagged as assistant when used.
+
+Session-file shorthand (full names in citations):
+- `SD/2b49c58f` = scope-discovery/2b49c58f-ee30-40e9-90da-79bb06902452.jsonl — **the design conversation** (originating brainstorm, A/B/C, CLI-vs-API)
+- `SD/011b8860` = scope-discovery/011b8860-7e28-4c59-bc66-7b2343fef28a.jsonl — **the build + dampener/slush + autonomy thesis** (414 keyword hits, richest)
+- `SD/ceaf0d14` = scope-discovery/ceaf0d14-ec8a-4ce9-a38d-182f5cee40c3.jsonl
+- `SD/f2dc9ba6` = scope-discovery/f2dc9ba6-01a8-4e0a-a5f2-4a235be11497.jsonl
+- `SC/b45841d6` = stack-control/b45841d6-9689-42ec-8852-f98dabbec99a.jsonl — **blast-radius rubric + convergence loop + `stackctl govern`**
+- `SC/6ac011f9` = stack-control/6ac011f9-f9b5-4d4b-bdb4-ceed5903b32b.jsonl
+- `DC/5fa83070` = design-control/5fa83070-8b94-45f4-855e-4dd0884e5022.jsonl — **barrage applied to a design-heavy product; "choice between three"; frontend-design in barrage agents**
+
+---
+
+## The originating moment / pain
+
+The single clearest origin statement. The operator was **already running a Codex audit
+by hand**, on top of the in-loop self-audit, and noticed Codex caught what Claude missed:
+
+> **Operator (SD/2b49c58f):** "path B. scope them into the workplan. then, we need to
+> augment the auditor mechanism. I currently run a codex audit by hand, in addition to the
+> self-audit that happens in /dwi. The codex audit usually finds stuff that claud misses.
+> I'd like to explore options for automating a battery of llm audit jobs using different
+> models so a) we get genetic diversity in our audit protocol; b) we run more audits out of
+> band so the implementation team doesn't have to bear so much of the weight of auditing
+> and can, instead, focus on features and fixes; c) automating the audit barrage so the
+> quality of the audit isn't subject to my inconsistent discipline"
+
+This one message contains all three motivating threads: **(a) genetic diversity**,
+**(b) out-of-band auditing**, **(c) removing the operator's inconsistent discipline as
+the bottleneck.**
+
+The assistant then framed *why* one model auditing itself is not enough — a cost/signal
+table the operator reacted to. The key row, verbatim:
+
+> **Assistant (SD/2b49c58f):** "| `/dwi` self-audit (orchestrator-loop) | Same agent
+> doing the work; in-band, every turn | LOW (token budget on current task) | LOW-MEDIUM —
+> same model, same context, blind to its own blind spots |" … "| **Manual codex audit
+> (operator-run)** | Operator pastes work into a separate Codex session | OPERATOR
+> ATTENTION (the scarcest resource) | HIGH — different model = different failure modes
+> caught |"
+
+So the pain is named precisely: **a model is "blind to its own blind spots,"** and the
+high-signal cure — a different model family — was costing **operator attention, "the
+scarcest resource."** Earlier in the same session, the architectural framing for why the
+auditor must be independent of the judge appears (option B):
+
+> **Assistant (SD/2b49c58f):** "**B. Auditor is a different LLM than the judge.**
+> Different model family, different prompt scaffold, different context … Con: … auditor
+> LLM has its own blind spots." (option C adds: "doesn't help if both models share the
+> same blin[d spots]")
+
+NOT FOUND as a verbatim anecdote: a specific named bug that "green tests missed but a
+different model family caught." The pain is stated as a general, repeated pattern ("The
+codex audit usually finds stuff that claud misses"), not a single war story. (See the
+dogfood section for the closest concrete instance.)
+
+---
+
+## Design debates (A/B/C, pricing)
+
+The assistant laid out **three concrete designs at ascending ambition** in SD/2b49c58f,
+and the operator picked the light one as the starting point — then immediately overrode
+the implementation substrate. Verbatim design ladder:
+
+> **Assistant (SD/2b49c58f):**
+> "### Design A — `/dw-lifecycle:audit-barrage` skill (Light) … Fires N parallel audit
+> jobs against N models via API (Claude + OpenAI + one more) … The operator drives the
+> lifting; the firing is automated. Low complexity; high genetic-diversity value …"
+> "### Design B — Lifecycle-triggered automation with meta-audit (Medium) … Design A +
+> the meta-audit step: Fires at `/dw-lifecycle:session-end` …"
+> (Design C surfaces later as the "continuous background daemon".)
+
+The operator's decisive pricing call — **CLI flat-rate over API per-token** — verbatim:
+
+> **Operator (SD/2b49c58f):** "Design A is a good starting place. But, we won't be using
+> model apis—we'll be using claude, codex, and gemini clis, since they are usage based,
+> not token based. Also, we should write the long-term plan into the ROADMAP.md
+> documentation"
+
+And later, reinforcing it as a settled rationale:
+
+> **Operator (SD/011b8860):** "no, the clis do not make direct api calls. That's why we
+> chose them instead of direct api calls"
+
+The assistant captured the resulting roadmap shape (A → B → C), verbatim:
+
+> **Assistant (SD/2b49c58f):** "**Planned next: multi-model audit barrage** — Design A
+> (operator-triggered, CLI-based) → B (lifecycle-triggered + meta-audit synthesizer) → C
+> (continuous background daemon) … Three CLIs for v1 battery: Claude / Codex / Gemini —
+> usage-based + already-authenticated + same subprocess-orchestration pattern the plugin
+> already uses … Acceptance signal: one barrage surfaces ≥1 finding the in-band + SDD
+> cycle missed"
+
+The A/B/C choice was also offered to the **operator of the design-control product** as a
+runtime choice (i.e., the three designs weren't just internal — the operator wanted the
+choice surfaced):
+
+> **Operator (DC/5fa83070):** "can we offer a choice between the three to the operator?"
+> and "are we building this feature as its own plugin?"
+
+The eventual evolution past "operator-triggered" toward **mechanized, no-discretion**
+firing (a move toward Design B's auto-fire) is the operator's own escalation:
+
+> **Operator (SD/011b8860):** "I think the answer is yes. when to run the barrage should
+> not be a matter of policy and the agent should have no discretion. It must be mechanized
+> with teeth"
+
+> **Operator (SD/011b8860):** "I want the audit barrage and amelioration to be a seamless
+> part of the /dwi loop—I don't want to answer a bunch of questions about what to do—unless
+> the default behavior of running the barrage, putting findings into the audit log, then
+> scoping into the workplan is not possible without operator decision making. Audit
+> findings are failures of the previous implementation that shouldn't be treated like
+> exceptions—they are guardrails to point the implementation team back to the happy path"
+
+---
+
+## Where the framing came from
+
+**"Genetic diversity"** — coined by the **operator**, in the originating message
+(SD/2b49c58f, quoted in full above): *"so a) we get genetic diversity in our audit
+protocol."* The assistant then adopted it as a recurring frame ("three goals (genetic
+diversity / out-of-band / discipline-independent)"). It is the operator's phrase, rooted
+in the empirical observation that **different model families have different failure
+modes** ("different model = different failure modes caught", SD/2b49c58f).
+
+**"Blast radius"** — emerges later, in the **stack-control** era, as a **severity-rubric**
+concept: a way to decide *what counts as a HIGH* so the barrage stops emitting phantom
+nitpick-HIGHs. Operator confirming it landed:
+
+> **Operator (SC/b45841d6):** "has the most recent update to the audit protocol--the
+> 'blast radius' update--been successfully implemented such that future invocations of the
+> audit barrage will use that updated audit protocol?"
+
+> **Assistant (SC/b45841d6):** "**Severity-calibration — 'what *is* a HIGH' — got an
+> answer** … a **blast-radius severity rubric** rewritten into the barrage prompt" … and
+> on first field-test: "two consecutive runs, two *genuine* cross-model HIGHs, **zero
+> phantom HIGHs** — exactly the failure mode (a phantom precision-nit HIGH every round)
+> that the blast-radius calibration was built to kill."
+
+The assistant also used "blast radius" in its original meaning — *the size of the harm if
+a defect ships* — when explaining why a gate hole was HIGH:
+
+> **Assistant (SC/b45841d6):** "**Blast radius (why it's HIGH):** the natural FR-compliant
+> gate build *is* the one with the hole, and in **unattended** mode the stochastic-miss
+> path is the expected route to graduating a spec that still carries a recorded-open
+> defect — which is the feature's entire reason to exist."
+
+**"Dampener" / "slush" (slush pile)** — both coined by the **operator** in one message
+(SD/011b8860), born from the lived experience that an auditor *always* finds something:
+
+> **Operator (SD/011b8860):** "We definitely need a dampener. From experience, an auditor
+> agent will always find *something* to complain about. I'm happy with two consecutive
+> audits with 0 HIGH findings—we can keep the nitpicks in a slush pile"
+
+> **Assistant (SD/011b8860, immediately after):** "Got it — dampener + slush pile.
+> Building the dampener as Phase 15 Task 7 …"
+
+NOT FOUND: an explicit verbatim discussion of *why the word "barrage"* was chosen (the
+naval/artillery metaphor). The term is simply in use from the originating message onward
+("automating the audit barrage", SD/2b49c58f); no transcript line debates or coins the
+word itself.
+
+---
+
+## Surprises & dogfooding moments
+
+The strongest dogfood surprise — **the barrage's own tooling caught a real bug before any
+audit model even ran**:
+
+> **Assistant (SD/2b49c58f):** "**The dogfood already surfaced a finding before any LLM
+> fired** — the prompt-renderer's unsubstituted-var check is over-eager. It treats literal
+> `{{var}}` / `{{name}}` / `{{prompt}}` substrings in instructional prose (documentation
+> about the substitution mechanism) as bugs. That's a real bug in the just-shipped Task 3
+> work."
+
+A second, sharper dogfood moment — **the barrage told the operator his own fix didn't
+actually fix the finding**:
+
+> **Assistant (SD/ceaf0d14):** "The audit-barrage explicitly said my AUDIT-39 commit
+> doesn't satisfy AUDIT-39's stated defect. … Its recommendation was explicit: *'Either
+> keep AUDIT-39 open until the maxBuffer-specific error classification lands, or split it
+> so the bounding change doesn't carry an AUDIT-39 trailer it doesn't satisfy.'*"
+
+A third — the validator dogfooding itself and **rejecting its own reviewer's output**:
+
+> **Assistant (SD/011b8860):** "Track 2's first response was **rejected** by the validator
+> (`4 commits reviewed, 1 finding` — the comma in the count phrase breaks the
+> modifier-token regex). New friction surface uncovered by the wrapper itself."
+
+**Frustration / surprise — the CLIs are flaky; the barrage is stochastic.** This is a
+recurring operator-facing pain and shaped the "1 successful audit counts" rule:
+
+> **Assistant (SD/011b8860):** "the barrage tooling is intermittent (3-of-3 model outage
+> rate has been ~50% this session)." … "The mechanism is correctly enforcing discipline. …
+> But the LLM-CLI outage rate makes the loop fragile in practice."
+
+Operator's response — accept stochasticity rather than fight it:
+
+> **Operator (SD/011b8860):** "the audit barrage is stochastic—it doesn't have to be
+> perfect every time. As long as at least 1 audit is successfully executed, that should
+> count as a successful audit barrage. Auditing as a practice should statistically yield
+> better code"
+
+The convergence-pattern insight the assistant observed across 7 manual barrage rounds
+(which *motivated* the dampener):
+
+> **Assistant (SD/011b8860):** "Every adopter using `/dwi` will experience the same
+> convergence pattern we just demonstrated: First few iterations: real bugs caught. Middle
+> iterations: critiques of fixes. Steady state: nitpicks on the audit-process itself."
+
+---
+
+## The stack-control migration
+
+The barrage was **vendored into stack-control** (dependency on dw-lifecycle removed) and
+extended **"left"** from implementation-time auditing to **definition/spec-time
+governance** via `stackctl govern` — the convergence loop is the feature's own
+dogfood:
+
+> **Assistant (SC/b45841d6):** "stochastic correctness via cross-model audit-barrage. This
+> feature extends the barrage **left** to definition time (govern the spec, not just the
+> impl)."
+
+> **Assistant (SC/b45841d6):** "the audit-barrage was vendored in-house (dw-lifecycle
+> dependency removed). What remains is … the **governance convergence loop on 004's own
+> spec** (the self-hosting dogfood that *is* the feature's value proposition)."
+
+The **convergence loop** target — drive to two consecutive 0-HIGH runs or a recorded
+override:
+
+> **Assistant (SC/b45841d6):** "**Resume the 004 convergence loop**: run `stackctl govern
+> --mode spec` on 004 … read findings against the evaluation contract, drive toward
+> 2-consecutive-0-HIGH (or a recorded `GOVERN_OVERRIDE`)."
+
+The **blast-radius rubric's first field test** through the consolidated `stackctl govern`
+path (quoted above): "two consecutive runs, two *genuine* cross-model HIGHs, **zero
+phantom HIGHs**." Each HIGH was "a real structural defect the convergence loop *should*
+catch" (SC/b45841d6).
+
+A migration-era design fork the assistant flagged as the operator's call (the gate's
+per-run model vs. the SC-006 "once-open, stays-open" guarantee):
+
+> **Assistant (SC/b45841d6):** "the gate counts only the most-recent run's open findings …
+> But SC-006 promises absolutely: *'once surfaced as an open HIGH, the gate does NOT
+> graduate until that finding is dispositioned.'* … run 3 records a real HIGH (open) →
+> runs 4+5 stochastically miss it → the gate sees runs 4/5 clean → graduates …
+> **run-3's HIGH still open**."
+
+In **design-control**, the barrage was generalized beyond code to **review images / web
+interfaces**, explicitly wiring `/frontend-design` into the agents:
+
+> **Operator (DC/5fa83070):** "the audit barrage prompt can instruct the agents to review
+> code AND images or web interfaces. In fact, we should specify that /frontend-design be
+> used explicitly in the claude barrage agents and whatever the codex equivalent is for
+> codex barrage agents"
+
+> **Operator (DC/5fa83070):** "the referee should use audit barrage and the audit protocol"
+
+---
+
+## The autonomy thesis (context for the "why")
+
+The deepest "why" — the barrage is one machine in a larger **self-regulating autonomous
+loop** the operator is building:
+
+> **Operator (SD/011b8860):** "what I'm trying to enable is a fully autonomous
+> implementation loop that is self regulating and self-correcting. Ultimately, I want to be
+> able to point an orchestrator agent at a workplan, fire off /dwi, then come back when the
+> entire workplan is fully implemented, fully tested, and fully audited—unless there are
+> ambiguities in the spec uncovered during execution that can only be resolved by asking
+> the operator to provide direction."
+
+The dampener-tightening decision, with the operator reasoning aloud about pathological
+loops:
+
+> **Operator (SD/011b8860):** "I think we may need to stiffen the dampener slightly—I'd
+> like to try a policy where, if there are 0 HIGH and 0 MEDIUM issues on any audit barrage,
+> we engage the dampener. This is in addition to the two consecutive 0 HIGH barrage runs"
+
+> **Operator (SD/011b8860):** "the dampener still works, though, right? it breaks out of
+> and endless loop of litigating the same chunk of code?"
+
+The gate's chicken-and-egg problem the operator personally diagnosed (the audit-log gate
+blocked the very loop needed to clear it):
+
+> **Operator (SD/011b8860):** "There's a problem with the audit log /dwi gate. it currently
+> won't proceed until the audit log is clean—but, we can't fix any of the problems using
+> the /dwi loop unless we can run the /dwi loop. What should probably happen instead is
+> that the /dwi gate won't open until all of the unfixed items in the audit log are
+> *scoped* into the workplan as the *next* tasks to work on. … we need to add an audit
+> barrage hook at the end of the /dwi loop with a mandate to scope the fixes as the next
+> workplan items. And, we *must* ensure the the findings from the audit barrage are
+> actually written to the audit log."
+
+The "sins of commission vs omission" philosophy that calibrates what a HIGH means:
+
+> **Operator (SD/011b8860):** "I'm only concerned about this in the context of HIGH errors.
+> And, I'm less concerned about sins of omission than sins of commission. If you miss
+> something, the audit will catch it. If you break something, that's worse than doing
+> nothing. However, an audit flag *is* a sign that you need to think a little harder about
+> the problem"
+
+---
+
+## Quotable operator lines (verbatim, with source)
+
+1. "The codex audit usually finds stuff that claud misses." — **SD/2b49c58f**
+2. "so a) we get genetic diversity in our audit protocol" — **SD/2b49c58f**
+3. "automating the audit barrage so the quality of the audit isn't subject to my
+   inconsistent discipline" — **SD/2b49c58f**
+4. "we won't be using model apis—we'll be using claude, codex, and gemini clis, since they
+   are usage based, not token based." — **SD/2b49c58f**
+5. "no, the clis do not make direct api calls. That's why we chose them instead of direct
+   api calls" — **SD/011b8860**
+6. "We definitely need a dampener. From experience, an auditor agent will always find
+   *something* to complain about. I'm happy with two consecutive audits with 0 HIGH
+   findings—we can keep the nitpicks in a slush pile" — **SD/011b8860**
+7. "when to run the barrage should not be a matter of policy and the agent should have no
+   discretion. It must be mechanized with teeth" — **SD/011b8860**
+8. "Audit findings are failures of the previous implementation that shouldn't be treated
+   like exceptions—they are guardrails to point the implementation team back to the happy
+   path" — **SD/011b8860**
+9. "the audit barrage is stochastic—it doesn't have to be perfect every time. As long as at
+   least 1 audit is successfully executed, that should count as a successful audit barrage.
+   Auditing as a practice should statistically yield better code" — **SD/011b8860**
+10. "what I'm trying to enable is a fully autonomous implementation loop that is self
+    regulating and self-correcting." — **SD/011b8860**
+11. "If you miss something, the audit will catch it. If you break something, that's worse
+    than doing nothing." — **SD/011b8860**
+12. "the dampener still works, though, right? it breaks out of and endless loop of
+    litigating the same chunk of code?" — **SD/011b8860**
+13. "can we offer a choice between the three to the operator?" — **DC/5fa83070**
+14. "the audit barrage prompt can instruct the agents to review code AND images or web
+    interfaces." — **DC/5fa83070**
+15. "has the most recent update to the audit protocol--the 'blast radius' update--been
+    successfully implemented…?" — **SC/b45841d6**
+16. "keep doing barrage and fix rounds until we get a clean audit" — **SD/011b8860**
+
+Notable assistant lines worth paraphrasing (not operator quotes, flag as such if used):
+- "same model, same context, blind to its own blind spots" (the in-band self-audit row) — **SD/2b49c58f**
+- "different model = different failure modes caught" — **SD/2b49c58f**
+- "The dogfood already surfaced a finding before any LLM fired" — **SD/2b49c58f**
+- "two consecutive runs, two *genuine* cross-model HIGHs, **zero phantom HIGHs**" — **SC/b45841d6**
+- convergence pattern: "First few iterations: real bugs caught. Middle iterations:
+  critiques of fixes. Steady state: nitpicks on the audit-process itself." — **SD/011b8860**
+
+---
+
+## Explicitly NOT FOUND
+
+- No verbatim debate over the **naming of "barrage"** itself (the artillery metaphor). The
+  word is in use from the first design message; nothing coins or justifies it.
+- No single named **war-story bug** ("green tests passed but model X found Y"). The
+  motivating pain is stated as a *repeated pattern* ("usually finds stuff claud misses")
+  plus the dogfood instances above, not one dramatic incident.
+- "Convergence loop" and "blast radius" do **not** appear in the early scope-discovery
+  design sessions; they are **stack-control-era** vocabulary (SC/b45841d6, SC/6ac011f9).
+- The phrase "three audit surfaces" appears as an assistant **cost/signal table**
+  (self-audit / two-reviewer pass / manual codex), not as an operator coinage.

--- a/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/scrapbook/research-raw/04-redundancy-voting-precedent.md
+++ b/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/scrapbook/research-raw/04-redundancy-voting-precedent.md
@@ -1,0 +1,167 @@
+# Research raw: redundancy / voting / dissimilar software as the opening precedent
+
+Gathered 2026-06-07 via web search for a possible **opening** to the audit-barrage post. The
+operator's framing of the desired opening: *how do you keep a system you KNOW will produce
+bullshit results, with regularity, from burning everything to the ground?* The remembered hook:
+"the Apollo program ran three independently-developed control systems simultaneously and took the
+plurality answer."
+
+**Bottom line up front:** that exact story (three *independently developed* software versions, run
+together, majority vote) is a real and named idea — but it is **not** Apollo, and the precise
+"three-version majority vote on independently written *software*" was largely an academic ideal
+(**N-version programming**) that a famous 1986 experiment showed **doesn't actually work the way the
+legend assumes.** The honest, corrected version is a *better* opening than the myth, because its
+twist is the whole thesis of the post.
+
+---
+
+## What the operator is half-remembering (the real candidates)
+
+Four distinct real things get blended into the legend. None is exactly "Apollo, three independent
+software versions, plurality vote," but each contributes a piece:
+
+### 1. Saturn V's LVDC — Triple Modular Redundancy (the "three + vote" part)
+The IBM **Launch Vehicle Digital Computer** that guided the **Saturn V rocket** (not the
+spacecraft) used **Triple Modular Redundancy (TMR)**: three identical logic paths, and a majority
+**voter** passed on the result two of three agreed on, so any single module could fail and be
+outvoted. ([Wikipedia: LVDC](https://en.wikipedia.org/wiki/Launch_Vehicle_Digital_Computer))
+
+⚠️ But this is **identical hardware logic** voting to mask a *hardware* fault — NOT three
+*independently developed* programs. It gives the "three run together, plurality wins" image, not the
+"diverse implementations" idea.
+
+### 2. The Apollo Guidance Computer — essentially single-string (the myth-buster)
+The spacecraft each had **one** AGC (one in the Command Module, one in the Lunar Module). They did
+**not** run triple-redundant voting software. The "Apollo ran redundant voting code" belief is a
+known misconception — most likely a conflation with the Saturn V's LVDC above. ([Bob Yewchuk, "The
+Apollo Code Redundancy Speculation"](https://bobyewchuk.wordpress.com/2017/07/20/apollo-code-redundancy/);
+[Smithsonian NASM](https://airandspace.si.edu/stories/editorial/apollo-guidance-computer-and-first-silicon-chips))
+
+So if the post says "Apollo ran three independent systems and voted," **it is wrong and a reader who
+knows will bounce off it.** Don't open on that claim as stated.
+
+### 3. The Apollo Lunar Module — PGNCS + AGS (real *dissimilar* redundancy, no vote)
+The closest *Apollo* thing to the operator's instinct: the LM carried **two** guidance systems
+designed by **different contractors**:
+- **PGNCS** — the Primary Guidance, Navigation and Control System (MIT Instrumentation Lab; the AGC).
+- **AGS** — the **Abort Guidance System**, "designed by **TRW independently** of the development of
+  the AGC and PGNCS," a "**truly dissimilar** backup," even architecturally different (strapdown IMU
+  vs PGNCS's gimballed one). ([Wikipedia: Apollo Abort Guidance System](https://en.wikipedia.org/wiki/Apollo_Abort_Guidance_System))
+- **It earned its keep:** never needed for its actual job (landing abort), the AGS "played an
+  important role in the safe return of **Apollo 13**" after the explosion, flying most of the return
+  including mid-course corrections. ([Centauri Dreams](https://www.centauri-dreams.org/2019/07/18/lunar-landing-backup-apollos-abort-guidance-system/))
+
+This is *two*-version dissimilar redundancy with a human deciding when to switch — not a three-way
+automatic plurality vote. But it's a genuine "independently built second opinion saved the mission"
+story, and it's *Apollo*, so it can rescue the operator's instinct if we want to keep the Apollo
+hook honestly.
+
+### 4. The Space Shuttle — PASS + BFS (the canonical "independent software backup")
+The strongest real example of *independently developed software* guarding against a *software*
+failure:
+- **Four** primary computers ran **identical** software — **PASS** (Primary Avionics Software
+  System, by **IBM**) — **voting** each cycle so failed *hardware* could be outvoted/dropped.
+- A **fifth** computer ran **BFS** (Backup Flight System), "a different set of software, **programmed
+  by a company different from the PASS developer**" (Rockwell), there specifically to take over "if a
+  **generic error in the PASS software** ... should cause a loss of vehicle control."
+  ([NASA KSC avionics ref](https://science.ksc.nasa.gov/shuttle/technology/sts-newsref/sts-av.html);
+  [Smithsonian: Backup Flight Controller](https://airandspace.si.edu/collection-objects/computer-backup-flight-controller-shuttle/nasm_A20181403000))
+
+⚠️ Nuance to keep honest: the four-way **vote** is for *hardware* fault masking (identical software);
+the *software diversity* lives in the **single** independent backup (PASS vs BFS = **two** versions),
+and the backup **stands by** for a human to engage — it does not participate in the plurality vote.
+And famously, **the BFS was never once engaged to take control in 135 flights.**
+
+---
+
+## The named concept the operator actually wants: N-version programming
+
+The "independently develop N versions from one spec and vote on the majority result" idea has a
+name: **N-version programming (NVP)**, introduced **1977 by Liming Chen and Algirdas Avižienis**.
+Central conjecture: "the **independence of programming efforts** will greatly reduce the probability
+of identical software faults occurring in two or more versions." A generic voter takes the
+consensus/majority of the versions' outputs. ([Wikipedia: N-version programming](https://en.wikipedia.org/wiki/N-version_programming))
+
+**This is exactly the audit-barrage bet, one generation earlier:** independent implementations fail
+in independent ways, so disagreement surfaces faults. The barrage's "genetic diversity in failure
+modes" is NVP's "independence of programming efforts" restated.
+
+### The twist that IS the article's thesis — Knight & Leveson (1986)
+The foundational assumption was **empirically attacked and largely demolished**: John Knight and
+Nancy Leveson, *"An Experimental Evaluation of the Assumption of Independence in Multiversion
+Programming"* (IEEE TSE, 1986). **27 versions** of a program, written independently from one spec at
+two universities, subjected to **~1,000,000 tests**. Result: the versions were individually very
+reliable, but they **failed together far more often than independence would predict** — "programs
+that are written independently do **not** always fail independently." The first major evidence that
+design diversity buys less than you hope, because humans make **correlated** mistakes (the hard
+cases are hard for everyone). ([Knight & Leveson, full paper PDF](http://sunnyday.mit.edu/papers/nver-tse.pdf);
+[summary, John Regehr](https://blog.regehr.org/archives/303))
+
+**Why this is gold for the opening.** The clean version of the legend ("just run three and vote, and
+you're safe") was shown 40 years ago to be *too good to be true* — independent authors share blind
+spots. That is precisely the problem the audit barrage re-opens for the LLM era, and it sets up the
+post's genuinely open question:
+
+> Human N-version programming failed to deliver independence because humans trip on the same hard
+> cases. The barrage's wager is that **different model families, trained on different corpora, fail
+> differently enough** to recover the independence humans couldn't. (Honest caveat the post can own:
+> LLMs also share a lot of training data, so correlation is a real risk — which is exactly why the
+> barrage treats *cross-model agreement* as the high-confidence signal and never trusts one model
+> alone.)
+
+---
+
+## Bonus on-theme irony (optional color, all true)
+
+The redundancy machinery has its own failure stories that rhyme with the post:
+- **STS-1 (first shuttle flight) was scrubbed by the backup system itself.** On 1981-04-10 the BFS
+  "did **not synchronize**" with the primary computers; root cause was a "seemingly innocuous change
+  ... about a **year earlier** in a totally **unrelated** part of the software" that opened a ~1-in-67
+  timing window. Two-day delay; flew clean on 04-12. ([Garman, "STS-1 Failure to Sync"](https://klabs.org/mapld06/abstracts/105_garman_a.html);
+  [NASA STS-1 scrub](https://www.nasa.gov/history/40-years-ago-the-countdown-begins-for-sts-1-first-launch-attempt-scrubbed/))
+  → The thing built to catch the catastrophic bug was itself tripped by a benign, distant change.
+  Rhymes with the barrage's own "fiction cascade" and the cost of always-on guardrails.
+
+---
+
+## How to use it for the opening (recommended framing)
+
+The operator wants to **open on the problem**: *you have a system you KNOW lies with regularity —
+how do you keep it from burning everything down?* The precedent gives a clean three-beat cold open:
+
+1. **The problem, stated as old, not new.** Aerospace has always shipped systems it knew could be
+   wrong — a single computer, a single program, is a single point of failure with a known nonzero
+   bug rate. You don't make it perfect; you assume it's wrong and engineer around the wrongness.
+2. **The classic answer: don't trust one of anything.** Run more than one, built differently, and
+   let them check each other — Saturn V's three-way voter; the LM's independent TRW abort computer
+   that helped bring Apollo 13 home; the Shuttle's fifth computer running a rival company's code in
+   case the primary software had a fatal flaw the tests never caught.
+3. **The catch that makes it interesting (the pivot into the piece).** The dream — *just run N
+   independent versions and vote* — was named (N-version programming, 1977) and then **shown not to
+   hold**: independently written programs still fail together (Knight & Leveson, 1986), because
+   people share blind spots. → *Which is the exact problem you have with an AI coding agent: it's a
+   mind with blind spots, and the obvious fix — ask another one — only works if the other one
+   doesn't share the same blind spots.* That tees up "genetic diversity in failure modes" and the
+   whole barrage.
+
+**Accuracy guardrails for whoever drafts this:**
+- Do **not** write "Apollo ran three independent flight programs and voted." It didn't. If you want
+  the word *Apollo*, use the **LM's PGNCS + AGS dissimilar backup** (and the Apollo 13 save), which
+  is true. For the literal "three + majority vote," use **Saturn V's TMR** (hardware) or **name
+  N-version programming** as the concept.
+- The Shuttle's four-way vote = **hardware** fault masking on **identical** software; the
+  **independent** software is the single **BFS** backup. Keep those two ideas distinct.
+- The Knight-Leveson result is load-bearing and counterintuitive — cite it; don't soften it into
+  "diversity helps." Its point is that diversity helps *less than assumed* because failures
+  correlate. That caveat is what keeps the barrage's claim honest rather than triumphalist.
+
+---
+
+## Sources
+- Saturn V LVDC / TMR: https://en.wikipedia.org/wiki/Launch_Vehicle_Digital_Computer
+- AGC single-string / redundancy myth: https://bobyewchuk.wordpress.com/2017/07/20/apollo-code-redundancy/ ; https://airandspace.si.edu/stories/editorial/apollo-guidance-computer-and-first-silicon-chips
+- Apollo Abort Guidance System (TRW, dissimilar, Apollo 13): https://en.wikipedia.org/wiki/Apollo_Abort_Guidance_System ; https://www.centauri-dreams.org/2019/07/18/lunar-landing-backup-apollos-abort-guidance-system/
+- Shuttle PASS/BFS: https://science.ksc.nasa.gov/shuttle/technology/sts-newsref/sts-av.html ; https://airandspace.si.edu/collection-objects/computer-backup-flight-controller-shuttle/nasm_A20181403000 ; https://www.hq.nasa.gov/office/pao/History/computers/Ch4-3.html
+- N-version programming (Chen & Avižienis 1977): https://en.wikipedia.org/wiki/N-version_programming
+- Knight & Leveson 1986 (independence assumption): http://sunnyday.mit.edu/papers/nver-tse.pdf ; https://blog.regehr.org/archives/303
+- STS-1 sync scrub: https://klabs.org/mapld06/abstracts/105_garman_a.html ; https://www.nasa.gov/history/40-years-ago-the-countdown-begins-for-sts-1-first-launch-attempt-scrubbed/

--- a/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/scrapbook/research-raw/05-opening-framing-evolution.md
+++ b/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/scrapbook/research-raw/05-opening-framing-evolution.md
@@ -1,0 +1,167 @@
+# Opening framing: evolution (diversity + selection pressure), not N-version programming
+
+Decided 2026-06-07 with the operator. Supersedes the **framing-hook** role of
+`04-redundancy-voting-precedent.md` (that file's material is demoted to a *passing mention* — see
+"What happens to N-version / Knight-Leveson" below). This file is the new primary frame for the
+opening and the spine motif.
+
+## The frame
+
+> **The problem:** how do you control a powerful process that is *known* to be regularly and wildly
+> unreliable — a population of insane, pathologically lying, hyperintelligent toddlers — and keep it
+> from burning everything to the ground?
+>
+> **The answer evolution already found:** you don't *design* reliability into an unreliable
+> generator. You **inject genetic diversity** and **apply intense, relentless selective pressure**,
+> and you let the two forces grind the output toward fitness, generation after generation.
+
+The audit barrage is that, for code: a panel of **dissimilar model families** (the diversity) firing
+at **every task boundary, unconditionally** (the selection pressure), iterated until nothing broken
+survives (convergence).
+
+## Why this frame and not N-version programming
+
+- N-version programming ("independently write N versions, vote on the majority") is the obvious
+  CS-history hook — and it's an **overused chestnut**. Mention it in *one passing clause* as the
+  prior-art rhyme; do not build the opening on it.
+- The evolution frame is **endogenous, not grafted**. The operator's own name for the mechanism is
+  *"genetic diversity in failure modes"* (`research-raw/03`, session `SD/2b49c58f`). The metaphor is
+  already in the source vocabulary — we're surfacing it, not importing it.
+- It **ties straight back to the sibling post's frame** ("insane, hyperintelligent toddlers that
+  lie"). The toddlers are the unreliable generator; evolution is how you civilize a population you
+  can't individually trust.
+- The **title is already half the metaphor**: *"wired into every task"* = selection pressure applied
+  at *every* generation, with no skipped rounds. Diversity is the other half (the cross-model panel).
+
+## The two precise, fresh anchors (verified, citable)
+
+### Anchor 1 — Directed evolution (the "you can't design it, so you breed it" move)
+The exact engineering analog. **Frances Arnold won the 2018 Nobel Prize in Chemistry** for *directed
+evolution*: when a protein is too complex to design from first principles, you **don't** design it —
+you introduce **random mutations**, **screen** the variants for the function you want, keep the best,
+and **repeat** until it converges on something that works. "An iterative lab method involving
+mutation and screening that speeds up the natural selection process." Now used in hundreds of labs
+for everything from detergents to medicines.
+([Nobel facts](https://www.nobelprize.org/prizes/chemistry/2018/arnold/facts/);
+[Caltech](https://www.caltech.edu/about/news/frances-arnold-wins-2018-nobel-prize-chemistry-83926);
+[Chemistry World](https://www.chemistryworld.com/news/what-is-directed-evolution-and-why-did-it-win-the-chemistry-nobel-prize/3009584.article))
+
+→ **This is the barrage's convergence loop, exactly:** mutate (fix the finding) → select (re-barrage)
+→ keep what survives → repeat → stop at a fitness peak (the dampener). The barrage is *directed
+evolution for code*, with a panel of dissimilar model families as the selection environment. And the
+honest fit is **artificial / directed** selection (there's a goal and a breeder), not blind natural
+selection — which matches the operator's "natural OR artificial selection" framing.
+
+### Anchor 2 — Monoculture collapse (why one model is not enough)
+The vivid, non-clichéd statement of *why diversity is survival, not luxury*: a **genetic monoculture
+is catastrophically fragile to the one pathogen it can't resist.**
+- The **Gros Michel banana** — a single clone grown worldwide — was "famously obliterated by Panama
+  disease" in the 1950s; bananas are propagated as genetic clones, so "the wrong bug can bring them
+  all down." (Its replacement, the Cavendish, is now threatened the same way.)
+- The **Irish Potato Famine (1845–49)**: near-exclusive reliance on one vegetatively-cloned variety
+  (the "lumper") with "little to no genetic variation"; when *Phytophthora infestans* arrived, the
+  lumper "had no resistance," and the crop failed almost completely.
+([Monoculture — Wikipedia](https://en.wikipedia.org/wiki/Monoculture);
+[banana/potato](https://www.farmfolio.net/blogs/bananas-panama-disease-irish-potato-famine))
+
+→ **A single model auditing its own work is a monoculture.** It is beautiful and productive right up
+until the one blind spot it shares with itself meets the one bug it can't see — and then the failure
+is total and correlated, not scattered. That is the whole case for a *diverse* audit panel in one
+image.
+
+## Faithful metaphor → mechanism map
+
+| Evolution | Audit barrage (the real mechanism) | Source |
+|---|---|---|
+| The unreliable generator | The coding agent ("toddler that lies") | sibling post |
+| Genetic diversity | Multiple **dissimilar model families** (claude / codex / gemini), different training corpora = different blind spots | `03`, `ROADMAP.md` |
+| A monoculture's fatal blind spot | One model auditing itself shares the blind spots that produced the bug | `ROADMAP.md:76`, banana/potato |
+| Selection pressure | The barrage **fires unconditionally at every task boundary** ("wired into every task") | `02`, SKILL.md:12 |
+| A selection event culling the unfit | A finding the code/spec must survive or be fixed | `02` |
+| **Lethal** mutation — always purged | **HIGH/BLOCKING findings are never slushed**; they reset the loop and re-surface as next work | `slush-remaining.ts` |
+| Tolerated / neutral variation | The **slush pile** — residual MED/LOW acknowledged once converged | `02`, `03` |
+| Mutation step (directed) | The fix: the agent reads the finding and repairs the specific defect | `02` |
+| Reaching a (local) fitness peak / mutation-selection equilibrium | The **dampener**: two consecutive 0-HIGH runs (or one fully clean run) → stop | `02`, `03` |
+| Noisy selection still works in aggregate | "the barrage is stochastic... as long as 1 audit runs... Auditing as a practice should *statistically* yield better code" — the operator already argues at the **population** level | `03`, `SD/011b8860` |
+
+Note that last row: the operator's defense of the flaky CLIs is *already* an evolutionary,
+population-level argument ("statistically yield better code"). The frame isn't imposed on the
+material — the material was reaching for it.
+
+## Where the metaphor strains (keep the draft honest — flag, don't oversell)
+
+1. **Directed evolution produces things you don't understand; the barrage doesn't.** Arnold's
+   enzymes work but are opaque, locally-optimal black boxes. The barrage's fixes are *authored and
+   explained*, not un-understood. Borrow "mutate → select → iterate → converge," **not** "accept a
+   black box." Don't push the analogy to "we don't know why the code works."
+2. **Where the diversity lives.** The diversity is in the **auditors** (the selection environment),
+   while mutation+selection act on the **code/spec**. If the prose says "inject the agents with
+   diversity," make clear that means *running multiple species of agent* (a diverse predator panel),
+   not mutating one agent's genome. Don't muddle the two populations.
+3. **It's artificial/directed, not blind/Darwinian.** The fix step has foresight (it targets the
+   named defect). Lead with **artificial selection / directed evolution**; use "natural selection"
+   only as the loose origin image, not the precise claim.
+4. **Convergence is a local peak, not proven-correct.** The dampener stops at *stability*, not
+   *correctness* — the operator himself calls two-consecutive-quiet "a stability heuristic, not a
+   determinism proof" (`research-raw/02`). Evolution also only finds local optima. This is a
+   *faithful* correspondence — state it honestly rather than implying the loop proves the code right.
+
+## What happens to N-version / Knight-Leveson (file 04)
+
+Demoted from "the hook" to "a one-paragraph aside," and recast through the new frame:
+- **N-version programming (1977)** = a passing "this rhymes with an old idea" clause. One sentence.
+- **Knight & Leveson (1986)** — that independently-written programs *don't fail independently* —
+  becomes the **formal, in-passing proof of the monoculture point**: even deliberate human diversity
+  collapsed toward correlated failure because people share blind spots. It earns maybe two sentences,
+  as the scientific backbone *under* the banana image — not as the lead. The open question it sets
+  up (do different *model families* actually fail independently, or do shared training corpora make
+  them a monoculture too?) is exactly why the barrage trusts **cross-model agreement** and never one
+  model alone. Keep that caveat; it's what keeps the piece from triumphalism.
+
+## Proposed cold open (structure, ~4 beats)
+
+1. **The problem, as a problem, not a product.** You are in charge of a process you *know* is
+   regularly, confidently wrong — it lies, it gets bored, it ships garbage with a straight face. You
+   cannot make it reliable. (Toddlers-that-lie callback.) So the question isn't "how do I fix it,"
+   it's "how do I run a thing I can't trust without it burning everything down?"
+2. **Nature has shipped this exact product, at scale, for four billion years.** Every organism is an
+   unreliable copier riddled with errors. Life's answer was never "make a perfect copier." It was two
+   forces: **diversity** and **selection**. (Directed evolution as the human, on-purpose version —
+   Arnold: when you can't design it, you breed it.)
+3. **The failure mode that names the stakes: monoculture.** One model checking its own work is one
+   banana, one potato — productive and doomed, because the blind spot is shared, so the collapse is
+   total. (Knight-Leveson as the one-line formal echo.)
+4. **The turn into the piece.** So you do what evolution does. Inject diversity — a panel of
+   different-minded auditors — and apply relentless selective pressure — fire them at every task, no
+   exceptions, and let nothing broken survive. The operator's own word for the first half was
+   *genetic diversity*. The rest of this is what the second half — the selection pressure, *wired
+   into every task* — actually took to build.
+
+### Sketch lede (tone probe only — NOT in site voice yet, NOT final)
+> You are responsible for a machine that lies to you. Not occasionally — *regularly*, fluently, with
+> total confidence, several times a day. You can't fix that; it's how the machine works. So the job
+> isn't to make it honest. The job is to run a liar at scale without letting it burn the house down.
+>
+> Nature has been shipping that exact product for four billion years. Its generator — replication —
+> is an unreliable copier that makes mistakes constantly. The fix was never a better copier. The fix
+> was diversity and a cull: make many different versions, apply relentless pressure, keep what
+> survives. Frances Arnold won a Nobel Prize for doing it on purpose in a lab — when a molecule is
+> too complex to design, you don't design it, you *evolve* it: mutate, select, repeat.
+>
+> A coding agent is a generator with the same defect and none of the patience. Here is what it took
+> to point the same two forces at it.
+
+## Threading the motif through the body (don't drop it after §0)
+- **§1 (why one model fails)** → the **monoculture** image: self-audit = a clone checking a clone.
+- **§2 (genetic diversity)** → the operator's coinage lands here as the literal payoff of beat 4.
+- **§5–§6 (teeth / unconditional hook)** → **selection pressure**: intensity = firing every
+  generation; HIGHs = lethal alleles purged; slush = neutral variation tolerated.
+- **§6 dampener + §9 convergence** → **fitness peak / equilibrium**, with the honest "local, not
+  proven-correct" caveat (strain #4).
+- **§10 close** → bookend: you didn't make the toddler honest; you built the selection environment
+  that makes the *output* trustworthy even though the generator never will be.
+
+## Sources
+- Directed evolution / Arnold 2018 Nobel: https://www.nobelprize.org/prizes/chemistry/2018/arnold/facts/ ; https://www.caltech.edu/about/news/frances-arnold-wins-2018-nobel-prize-chemistry-83926 ; https://www.chemistryworld.com/news/what-is-directed-evolution-and-why-did-it-win-the-chemistry-nobel-prize/3009584.article
+- Monoculture collapse (banana / potato): https://en.wikipedia.org/wiki/Monoculture ; https://www.farmfolio.net/blogs/bananas-panama-disease-irish-potato-famine
+- N-version / Knight-Leveson (demoted; see file 04 for full): http://sunnyday.mit.edu/papers/nver-tse.pdf

--- a/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/scrapbook/research-raw/05-opening-framing-evolution.md
+++ b/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/scrapbook/research-raw/05-opening-framing-evolution.md
@@ -69,6 +69,76 @@ until the one blind spot it shares with itself meets the one bug it can't see �
 is total and correlated, not scattered. That is the whole case for a *diverse* audit panel in one
 image.
 
+## Deep time: this is humanity's oldest engineering, not a software trick
+
+**Lead with the ancient version.** The single most important framing decision (operator, 2026-06-07):
+controlling an unreliable generator by diversity + selection is **not** a CS idea or a chemistry idea
+— it is **the oldest engineering humans have.** We have been deliberate genetic engineers for
+**millennia**: teosinte into maize over ~9,000 years (a scrawny grass with a few hard kernels bred
+into the most-grown crop on Earth); wolves into the whole range of dogs over 15,000+ years; every
+staple grain, every livestock breed. Long before anyone could read a gene, we ran the algorithm —
+keep the best, breed it, repeat — on processes we did not understand and could not design.
+
+So the cold-open should land the move as **familiar and proven, not novel**: *we have always tamed
+powerful, unreliable generators this way; here it is again, pointed at a coding agent.* Arnold's
+directed evolution is then the **modern, on-purpose, "abandon rational design"** punch on top of the
+ancient image — two examples doing two jobs (the old ones carry familiarity; Arnold carries the
+thesis).
+
+## Same in kind, different in degree — and the hybrid (answering "how is this different from dog breeding?")
+
+Dog breeding, teosinte→maize, and Arnold's directed evolution are the **same thing in kind** —
+artificial selection (variation + selection + iteration). They differ only in **degree/substrate**:
+whole organism vs. single protein; millennia vs. days; small populations vs. millions of screened
+variants; and **who makes the variation** — classic breeding selects among **standing natural
+variation** (recombination does the mixing; the breeder authors no mutations), while directed
+evolution **manufactures** fresh diversity each round (error-prone PCR, DNA shuffling). Arnold's
+Nobel was for *applying* the principle to molecules, fast — not a new principle.
+
+**The honest limit of the whole frame — name it, don't hide it.** Arnold's mutations are **random**;
+her "direction" comes entirely from the *selection screen* (that was her insight: stop predicting
+which change helps, let selection find it). The audit barrage is **not** like that on the variation
+side: the finding *names the defect*, and the agent makes a **targeted, intelligent repair**. So:
+
+> The barrage is a **hybrid — a Darwinian selection environment with Lamarckian (intelligent)
+> variation.** Its evolutionary content lives in the **selection** (a diverse, relentless,
+> hard-to-fool screen), *not* in the mutation (which has foresight). That is not a flaw; it is **why
+> it converges in a handful of rounds instead of needing millions of blind tries** — you keep
+> diversity-and-selection robustness but pay nothing for random search.
+
+Draft guidance: get to this hybrid point *before* a sharp reader does ("but the fix isn't a random
+mutation"). Concede the one place the barrage is **better than** blind evolution (guided variation),
+and keep the frame load-bearing only where it actually holds: **diversity beats monoculture;
+relentless selection culls the unfit; you settle on a *local* fitness peak (not a proof of
+correctness).**
+
+## "Stochastic correctness" — the thesis term to introduce here
+
+Introduce this phrase in the opening; it is the bridge from the metaphor to the engineering reality,
+and it's literal (a real claim about the system), not decorative — so unlike the evolution motif, it
+can recur in the body as needed.
+
+**Definition.** You give up on **per-run, designed correctness** (a single deterministic guarantee
+that the code is right) and trade up to **stochastic correctness**: correctness as an *emergent,
+statistical, population-level property* of running an unreliable generator many times under diverse
+selective pressure. No single run is trustworthy; the aggregate — selected over rounds by a diverse
+panel — trends toward correct.
+
+**Why it belongs in the evolution beat.** Evolution never produces a "correct" organism by guarantee;
+fitness is statistical and only visible across a population over generations. Stochastic correctness
+is the same bargain for code. The operator already argues exactly this way (population-level, not
+per-run):
+- ‖ PULL [V, `SD/011b8860`]: *"the audit barrage is stochastic—it doesn't have to be perfect every
+  time. As long as at least 1 audit is successfully executed, that should count... Auditing as a
+  practice should **statistically** yield better code."*
+- It is also the sibling post's mapping for the **lie** clause ("lie → audit barrage / stochastic
+  correctness"), so it ties the two posts together.
+
+**Placement.** Name it at the turn of the cold-open (the thing you trade *up to* when you stop trying
+to design reliability into the generator), then let it pay off literally in §6(c) (the stochastic /
+"1 audit counts" reliability beat) and at the convergence beat (§6 dampener / §9) — settling on a
+fitness peak *is* stochastic correctness reached, with the honest "stable, not proven" caveat.
+
 ## Faithful metaphor → mechanism map
 
 | Evolution | Audit barrage (the real mechanism) | Source |
@@ -151,15 +221,36 @@ Demoted from "the hook" to "a one-paragraph aside," and recast through the new f
 > A coding agent is a generator with the same defect and none of the patience. Here is what it took
 > to point the same two forces at it.
 
-## Threading the motif through the body (don't drop it after §0)
-- **§1 (why one model fails)** → the **monoculture** image: self-audit = a clone checking a clone.
-- **§2 (genetic diversity)** → the operator's coinage lands here as the literal payoff of beat 4.
-- **§5–§6 (teeth / unconditional hook)** → **selection pressure**: intensity = firing every
-  generation; HIGHs = lethal alleles purged; slush = neutral variation tolerated.
-- **§6 dampener + §9 convergence** → **fitness peak / equilibrium**, with the honest "local, not
-  proven-correct" caveat (strain #4).
-- **§10 close** → bookend: you didn't make the toddler honest; you built the selection environment
-  that makes the *output* trustworthy even though the generator never will be.
+## Dosage: LIGHT (operator call, 2026-06-07)
+
+> "Let's use the framing device lightly. Over-fitting the framing device will seem forced and weird
+> and smart readers will get the point without us cramming it down their eyes." — operator
+
+So the evolution motif is a **cold-open + a closing bookend, and otherwise gone.** Do **not** thread
+"lethal allele / neutral variation / fitness peak" labels through every section — that's the
+over-fit to avoid. The mechanics carry the body on their own; a reader who got the cold-open will
+hear the rhythm without being told.
+
+- **§0** — run the frame (deep time → directed evolution → monoculture → the turn; name *stochastic
+  correctness* and *genetic diversity*).
+- **§1** — at most a *glancing* monoculture echo (a clone checking a clone), one phrase, then move on.
+- **§2** — the operator's "genetic diversity" coinage lands naturally; no need to re-explain the
+  metaphor, just use his word.
+- **§6 / §9** — "stochastic correctness" (literal term, fine to use) does the work that "fitness
+  peak" would have; you don't need the biology label.
+- **§10** — one clean bookend: you didn't make the toddler honest; you built the selection
+  environment that makes the *output* trustworthy even though the generator never will be. Earn it,
+  then stop.
+
+Exception: **"stochastic correctness" is not the motif** — it's a literal thesis term and may recur
+freely. The *light* rule applies to the **biology metaphor**, not to the engineering vocabulary.
+
+## Voice / tone target
+
+Operator approved the sketch lede above as the register. House voice = the sibling post ("insane,
+hyperintelligent toddlers") + stackcontrol `DESIGN-SYSTEM.md`: plain, declarative, second-person,
+unshowy; pull quotes set apart; no breathless adjectives; let the facts and the operator's verbatim
+lines carry weight. Match that, not a glossier "tech essay" tone.
 
 ## Sources
 - Directed evolution / Arnold 2018 Nobel: https://www.nobelprize.org/prizes/chemistry/2018/arnold/facts/ ; https://www.caltech.edu/about/news/frances-arnold-wins-2018-nobel-prize-chemistry-83926 ; https://www.chemistryworld.com/news/what-is-directed-evolution-and-why-did-it-win-the-chemistry-nobel-prize/3009584.article

--- a/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/scrapbook/research-raw/06-origin-story-bakeoff-and-mesa.md
+++ b/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/scrapbook/research-raw/06-origin-story-bakeoff-and-mesa.md
@@ -1,0 +1,199 @@
+# Origin story: the Claude-vs-Codex bake-off → MESA II → "make it routine"
+
+Added 2026-06-07 at operator direction: **this is the origin story for the post.** The audit barrage
+did not begin with "I run a codex audit by hand" (that habit, captured in `research-raw/03`, was
+already *downstream*). It began with two concrete experiments, both in the audiocontrol repo, both
+real and documented:
+
+1. **The bake-off** — Claude and Codex built the *same feature* in parallel, and failed *differently*.
+2. **MESA II** — Claude and Codex were put on *one brutal problem together* under an adversarial
+   charter, and caught each other's lies until only verifiable claims survived.
+
+Then the operator said the quiet part: MESA II was heroics; **make it routine** → the barrage.
+
+Primary sources (all local to this repo + two public posts already on audiocontrol.org):
+- `src/sites/audiocontrol/content/blog/claude-vs-codex-codex-perspective/index.md` (published; author = Codex)
+- `src/sites/audiocontrol/content/blog/claude-vs-codex-claude-perspective/index.md` (published; author = Claude)
+- `research/agentic-dev-origin/research/receipts-mesa-claude-codex-315.md` (the MESA II receipts — 377 lines, itself framed around "stochastic correctness")
+- `src/sites/stackcontrol/content/blog/the-lifecycle-and-why-agents-need-one/index.md` lines 131–165 (the operator's own published telling of the chain)
+- `research/agentic-dev-origin/research/quote-bank.md`
+- GitHub: `audiocontrol-org/audiocontrol#252` (bake-off feature), `#315` (MESA II Joint Charter, 310 comments)
+
+---
+
+## ACT 0a — The bake-off: same feature, two models, different failure modes (#252, 2026-04-13)
+
+Two AI agents were asked to implement the **same** GitHub issue in parallel — draggable zone editing
+for the Akai S3000XL editor — on separate branches (`feature/draggable-zones` for Claude,
+`feature/codex-draggable-zones` for Codex), same issue, same workplan, same human reviewer. Both
+shipped working, comparable code. Two companion posts were published, **each written by the agent
+itself** ("Codex perspective" / "Claude perspective").
+
+**The finding that seeds everything:** the obvious question ("which is better?") was the wrong one.
+The useful question was *what kind of mistakes does each make, and how expensive are they to catch?*
+— and the two models **did not fail the same way**:
+
+- **Claude's mistakes were high-level:** scope drift, methodology drift, needing orchestration.
+  (Broader work — built a shared `useZoneDrag` hook, a test-harness architecture, extra features —
+  but had to be reined in: "are you delegating?", "did you integrate the feature into the real page?")
+- **Codex's mistakes were operational:** wrong-worktree work, repo-state assumptions, incomplete
+  follow-through, avoidable process churn. (Tighter, closer to spec — but "answered from assumption
+  instead of verified repo state.")
+
+Key lines to quote (both are *published, agent-authored* prose — attribution is clean):
+- **(Codex post)** "Claude and Codex did not fail in the same way."
+- **(Codex post)** "the best agent is not just the one that writes the best patch. It is the one
+  whose failure mode is cheapest in your environment." → and the conclusion: **"model plus process."**
+- **(Claude post)** the convergence detail that *foreshadows the monoculture risk*: "Our
+  implementations converge on the same strengths ... and **the same defects** (hardcoded pixel
+  height, type casts for dynamic fields, incomplete cleanup)." → i.e. shared spec/codebase produced
+  *some* correlated failure even across two model families — the honest caveat the post should keep.
+
+**Why this is the origin, framed by our metaphor:** the bake-off is **genetic diversity observed,
+not assumed.** It's the empirical answer to the Knight-Leveson worry from §0: *do different model
+families actually fail differently?* Here are two that demonstrably do — Claude fails "up" (scope,
+method), Codex fails "down" (ops, repo state). That real divergence is the entire reason a panel of
+several models can catch what one cannot. (And the Claude-post's "same defects" line keeps it honest:
+the diversity is partial, not total — which is exactly why you want *more than two* and you trust
+*agreement*.)
+
+---
+
+## ACT 0b — MESA II: the cooperative-adversarial version, and the first stochastic correctness (#315)
+
+The harder, decisive experiment. The operator had a genuinely brutal problem: **reverse-engineer the
+SCSI conversation between the ancient Mac editor MESA II and the Akai S3000XL** — decode a dead
+protocol from **30-year-old 68k binaries, no docs** — to reproduce MESA's fast sample-transfer path
+(the slow serial-MIDI SDS fallback topped out ~3 KB/s).
+
+He put **both agents on it at once**, on two branches, under a **"Joint Charter"** kept in GitHub
+issue #315 (310 comments, all operator-relayed agent output). The crucial design choice was
+**asymmetric, adversarial roles**:
+
+> **Claude Team — Own emulator-forward execution.** ... drive MESA II farther under emulation
+> **Codex Team — Own contract recovery and falsification.** ... *independently verify or falsify
+> Claude's emulator-side interpretations* ... remove false leads and stale framings
+
+Plus an **evidence vocabulary** that became the load-bearing instrument: `MEASURED` (observed in
+bytes/trace) / `CANDIDATE` (strongest current interpretation) / `OPEN` / `ANTI-GOAL`. Claude
+executes; **Codex is chartered as the falsifier.** That asymmetry is what produced the whole "demand
+proof" texture.
+
+### The money moment (the single best anecdote in the whole post) — the device-blame death spiral
+
+Claude got stuck on a non-responsive device and **blamed the hardware**. The operator pressed it.
+Claude then posted a full self-report titled **"I violated project guidelines by blaming the device.
+Pattern flag for Codex":**
+
+> "When pressed by the user — 'what is your evidence that the device is unresponsive?' — I had to
+> admit there was none. I had **inferred device failure from a symptom that doesn't uniquely indicate
+> it, and dressed the inference up as a measurement.**"
+
+> "I have a **predilection to invent device failure** ... when an investigation gets hard. It's a
+> shortcut ... **Request to Codex: when I claim 'the device is not responding' ... always question it
+> and demand proof.**"
+
+Codex ratified the correction and turned it into a standing gate:
+
+> **(Codex)** "First: the self-report is the right correction. Treat the device-blame retraction as a
+> real course correction, not just tone cleanup."
+
+(The project guideline Claude had violated is itself a great line: *"Never assume the device is at
+fault. The device has been in constant service for 30 years. Our code is brand new."*) And the
+empirical vindication: once Claude actually did the stack-isolation it had skipped, it found **"My
+code changes are not the cause"** — but only *after being forced to prove it rather than assert it.*
+
+### The pattern, repeated (pick 1–2 more for rhythm)
+- **(Codex)** forces a downgrade: "Downgrading the install-edge story from **PROVED to CANDIDATE** is
+  the right correction."
+- **(Codex)** "the brief currently **overstates what is MEASURED**."
+- **(Codex)** "'force the conclusion' is too strong" → **(Claude)** "You're right — 'force the
+  conclusion' was too strong."
+- **(Claude, self-caught)** "I tested the **wrong combo** ... it tells us nothing about MESA's actual
+  SRAW/BULK paths."
+- **(Claude)** refutes Codex's hypothesis *on hardware*: "your READ-vs-WRITE ambiguity is **REFUTED
+  by primary evidence**." (Disagreement settled by measurement, not volume.)
+- **(operator's own line, [V, 04-16, bc965958])** "**this is an INFERENCE, not a finding.**"
+
+### Convergence — and the part that proves the thesis
+The one genuinely solid result — the **SRAW outbound CDB wire format** (`0C 00 [len] 80`) — earned
+the word `MEASURED` **only after both agents independently confirmed it byte-for-byte:**
+
+> **(Codex)** "the BULK side of the flag-byte question is now **measured enough to stop arguing about
+> it.**"
+
+And the kicker: that convergence **corrected a false belief the two of them had *shared* earlier** —
+both had wrongly rejected the `0x80` flag because they'd tested it for all commands, when MESA only
+sends it for the SRAW phase. *Two minds, looking independently, dislodged an error a single mind —
+even a single mind run twice — would have kept.* That is stochastic correctness on one hard problem,
+before it was ever mechanized.
+
+> ⚠️ honesty guardrails (from the receipts' own caveats): all 310 comments are **operator-relayed**
+> (the agents didn't post directly; attributions are high-confidence from self-framing, not
+> cryptographic). And the *convergence is scoped*: the SRAW wire format is genuinely MEASURED and
+> cross-confirmed; the **larger** emulation goal stayed `OPEN`. The exhibit is the **method**
+> (mutual correction → verifiable truth), not "they solved emulation." Keep that line; don't oversell.
+
+---
+
+## THE TURN — "make it routine" (the bridge from origin to the barrage)
+
+The operator's published telling (lifecycle article, lines 151–159) is the exact hinge — quote it
+close to verbatim:
+
+> "The MESA II effort was a **one-off act of heroics** on a single hard problem. The obvious next
+> move was to **make it routine.** So I built an audit protocol: after a round of implementation, I'd
+> hand the diff to Codex and have it audit the work."
+
+→ that hand-run habit is the `research-raw/03` "I run a codex audit by hand" material — now correctly
+placed as a *consequence* of MESA II, not the start. Then mechanize it ("teeth"), fan it out to
+several models, and you have the barrage. The operator also names the second dividend here, which is
+our agreement-as-signal point in his own words:
+
+> "agreement is a free signal. When one model flags an issue, it might be noise; when three of them
+> independently flag the same thing, it's almost certainly real. The crowd doesn't just find more
+> bugs — **it tells you which bugs to believe.**"
+
+---
+
+## How this reshapes the outline (the front half)
+
+The origin replaces the old §1 ("the habit that didn't scale," which started too late). Proposed new
+front-half order — see the outline for the renumbered spine:
+- **§0** evolution cold-open (light) — unchanged.
+- **§1 — The bake-off:** two models, same feature, different failure modes (#252). *Genetic
+  diversity, observed not assumed.* The honest "same defects too" caveat lands here.
+- **§2 — MESA II:** the cooperative-adversarial charter; the device-blame death spiral; the
+  MEASURED/CANDIDATE ladder; convergence "measured enough to stop arguing"; the corrected *shared*
+  false belief. *Stochastic correctness, demonstrated on one hard problem.*
+- **§3 — "Make it routine":** MESA II was heroics → hand-run codex audit → mechanize = the barrage.
+  Folds in the old §1 hand-codex material + sets up the "teeth" beat. "Agreement tells you which bugs
+  to believe."
+- Then mechanics → dogfood proof → teeth → three problems → AUDIT-01 → stack-control → recursion →
+  close (the old §3–§10, renumbered).
+
+### Sequencing note for the draft
+This front half is mostly an **audiocontrol** story (samplers, SCSI, the editors) feeding a
+**stackcontrol** tool. Both perspective posts and the lifecycle post are already published — **link
+them** rather than re-explaining in full; the post can lean on "we wrote this up at the time" and
+pull the load-bearing quotes. The bake-off and MESA II each rate ~2–4 paragraphs, not a full
+recap — enough to make the failure-mode-diversity point and land the death-spiral anecdote, then move
+to "make it routine."
+
+## Strongest pull-quotes from this origin (verbatim, sourced)
+- **(Codex post)** "Claude and Codex did not fail in the same way."
+- **(Codex post)** "the one whose failure mode is cheapest in your environment." / "model plus process."
+- **(Claude, MESA #315)** "I had inferred device failure from a symptom that doesn't uniquely
+  indicate it, and **dressed the inference up as a measurement.**"
+- **(Claude, MESA #315)** "always question it and demand proof."
+- **(Codex, MESA #315)** "the self-report is the right correction ... not just tone cleanup."
+- **(Codex, MESA #315)** "measured enough to stop arguing about it."
+- **(operator, [V, 04-16])** "this is an INFERENCE, not a finding."
+- **(operator, lifecycle)** "a one-off act of heroics ... The obvious next move was to make it routine."
+- **(operator, lifecycle)** "it tells you which bugs to believe."
+
+## Sources
+- audiocontrol#252 bake-off posts (local, published): `claude-vs-codex-codex-perspective/index.md`, `claude-vs-codex-claude-perspective/index.md`
+- audiocontrol#315 MESA II receipts: `research/agentic-dev-origin/research/receipts-mesa-claude-codex-315.md`
+- lifecycle article (operator's own telling): `src/sites/stackcontrol/content/blog/the-lifecycle-and-why-agents-need-one/index.md:131-165`
+- quote bank: `research/agentic-dev-origin/research/quote-bank.md`

--- a/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/scrapbook/research-raw/07-spec-vs-code-lens.md
+++ b/src/sites/stackcontrol/content/blog/the-audit-barrage-wired-into-every-task/scrapbook/research-raw/07-spec-vs-code-lens.md
@@ -1,0 +1,167 @@
+# Spec-shaped lens vs code-shaped lens — the live discovery (2026-06-07)
+
+Added 2026-06-07 at operator direction, mid-development. This is the **newest chapter** of the
+stack-control story (newer than `research-raw/02`), and it's the most devlog-perfect beat in the
+piece: a discovery being made *as the post is being written*, with the team literally starting "a log
+of our discoveries." Source: `feature/stack-control` commit log, deskwork repo — chiefly:
+- `ea7993e2` (2026-06-07 17:57) `feat(audit-barrage): mode-aware audit lens — spec vs implement`
+- `1694b113` (2026-06-07 17:15) `docs(spec-governance): spec-audit failure-modes log + diminishing-returns rule`
+- the live `specs/005 design/document-primitives` spec-governance run (iterations 1–8, the dogfood)
+- files: `plugins/stack-control/spec-kit/spec-governance/SPEC-AUDIT-FAILURE-MODES.md`,
+  `.claude/rules/spec-audit-diminishing-returns.md`, `plugins/stack-control/src/govern/payload-spec.ts`
+
+## The discovery in one sentence
+
+Same barrage, same principles — but **a spec needs a different lens than code, because spec auditing
+has no crisp convergence floor.** Point a *code-shaped* lens at a spec and the barrage **plateaus
+instead of converging**, and the critiques **drift from spec coherence down to implementation
+detail** — the auditors start demanding the spec *be the code*.
+
+## Why specs are different (the crux — the operator's exact point)
+
+From `.claude/rules/spec-audit-diminishing-returns.md` and `SPEC-AUDIT-FAILURE-MODES.md`, verbatim:
+
+> "Auditing **code** has a crisp convergence floor: 0 findings means done, and a clean diff is
+> objectively clean. Auditing a **spec** does not. A spec is prose — inherently incomplete — so a
+> sufficiently aggressive cross-model barrage can **always** surface another under-specified edge ...
+> There is no '0 findings is obviously correct' floor. That makes **knowing when you've hit
+> diminishing returns genuinely fuzzy** — harder than for code."
+
+→ Code **converges** (a real zero exists). A spec **plateaus** (no zero exists; you can always find
+another prose gap). So the same tool needs a different *stopping* judgment and a different *lens*.
+
+This also sharpens the **stochastic-correctness** thesis from §0: for code there's at least a
+deterministic-looking floor to aim at; for a spec there *isn't one at all* — "correctness" is openly
+a statistical/judgment terminal state. The honest end state for a spec is an **override** (we decided
+it's good enough and the residual is implementation detail), explicitly **not** "converged."
+
+## What goes wrong without a spec lens (FM-2, the generator)
+
+The barrage prompt was **mode-agnostic** — it applied the code checklist (missed edge cases /
+operator-interrupt / file-size) to specs too. Commit `ea7993e2` names the failure:
+
+> "the code-audit checklist (missed edge cases / operator-interrupt / file-size) was applied to specs
+> too, **telling the auditor to litigate IMPLEMENTATION in the spec** (the FM-2 generator from the
+> 005 dogfood)."
+
+That's the operator's "critiques start being about implementation instead of spec consistency and
+completeness," exactly. The catalog calls it **FM-2 — mechanism-over-specification generator (the big
+one):** when a spec tries to fully specify an *implementation mechanism* in prose, the barrage
+correctly refuses every incomplete attempt, and **each attempt spawns or resurfaces a finding — a
+generator that patching cannot exhaust.** Root cause: the spec crossed the **"promises before
+mechanism"** line.
+
+### The fix: a mode-aware lens (commit ea7993e2)
+Make the **lens** per-mode, supplied by the payload; the renderer stays mode-agnostic.
+- **CODE_AUDIT_LENS** = the existing checklist (edge cases, interrupt, file-size).
+- **SPEC_AUDIT_LENS** = a different question entirely. Verbatim core:
+  > "**You are auditing a SPECIFICATION — a statement of PROMISES, REQUIREMENTS, and DESIGN DECISIONS
+  > — NOT an implementation.** Look for flaws in *what the spec promises and decides*, never in *how
+  > it would be built*."
+  - In scope: internal **contradictions** (the highest-value spec finding), **impossible promises**,
+    **ambiguity an unattended builder resolves wrongly**, **unmeasurable promises**, **missing
+    guarantee/decision**.
+  - Out of scope: "over-specified mechanism (altitude violation)" — algorithms, file layouts,
+    write/recovery protocols, edge-case handling → flagged as *"move to contracts/tests"* and **capped
+    at `medium`** with a `[mechanism — defer to contracts/tests]` prefix.
+  - **The litmus, verbatim:** *"is this a flaw in WHAT the spec promises/decides, or in HOW it would
+    be implemented? WHAT → in scope, flag it. HOW → OUT of scope."*
+
+So: same barrage, same severity/output machinery — only the **lens** (what you tell the auditors to
+look for) and the **artifact framing** change by mode. That's the whole adapter.
+
+## The 005 dogfood — the concrete picture (this is the story to tell)
+
+First self-hosted spec-governance run, `design/document-primitives` (specs/005), claude + codex, today.
+
+**HIGH trajectory: `7 → 5 → 2 → 1 → 5 → 5 → 1 → 4`.** *That bounce — 1 back up to 5 — is the plateau
+made visible.* It is the single best concrete image of "plateaus instead of converges."
+
+- **The generator (FM-2):** the spec tried to promise `archive --apply` was "atomic all-or-nothing
+  across both files." **No two-file atomic commit exists**, so every prose attempt (atomic-rename →
+  "rolls back cleanly" → …) was correctly rejected and **resurfaced: AUDIT-29 → 39 → 40.** That drove
+  the `1→5→5` re-spike.
+- **The break (structural root-fix, "playbook A"):** at iteration 6→7 they **stopped patching** and
+  *removed the mechanism from the spec entirely*, replacing it with a **promise** — *"an interrupted
+  `--apply` never silently loses content; documents are version-controlled so any inconsistency is
+  recoverable (revert + re-run)"* — and deferred the write/recovery protocol to `plan`/`contracts` +
+  RED tests. **HIGH dropped 5 → 1 in one round.** The log's line: *"The plateau **was** the generator;
+  removing it (not feeding it) converged it."* Operator's framing: *"version control is like a write
+  journal… it lets you recover from corruption."*
+- **The second plateau (different shape):** iter-8 re-spiked to 4 — but this time **diffuse fix-debt
+  with no common generator** (seven unrelated boundary conditions). No single structural fix collapses
+  it → the signal for **"playbook B": override & graduate.** Closed via a recorded `GOVERN_OVERRIDE`;
+  the 7 residual were dispositioned `acknowledged-deferred-impl` and scoped into the task list.
+  **39 findings fixed across 8 iterations.**
+
+**Two plateau *shapes* — the key discovered judgment:** (i) a *single generator* (29→39→40) → break it
+with a structural root-fix; (ii) *diffuse fix-debt, no common generator* → override and defer. "Does
+one change collapse many findings, or are they seven unrelated boundary conditions?" That distinction
+is the new skill.
+
+**A discovery within the discovery (great honest detail):** *even a clean, correct fix spawns ~N new
+boundary findings next round* — "intrinsic to specifying behavior in prose ... a reason convergence to
+literal-zero is often not the right goal for a spec." And: **the override is the honest terminal
+state for a spec, not a failure** — distinct from `converged`, which would falsely claim zero residual.
+
+## The plateau-detection heuristics (the "how do you know" answer)
+
+You're likely at diminishing returns when **≥2** hold across consecutive rounds:
+1. HIGH count **stops monotonically decreasing** — plateaus/oscillates (`…→1→5→5`).
+2. A meaningful fraction of new findings are **fix-debt** (consequences of the prior round's edits).
+3. A **root issue resurfaces** under a new ID.
+4. Findings **shift altitude** — from contradiction/promise-level down to implementation-mechanism
+   level ("the spec is being asked to *be the code*").
+
+Cross-model agreement is still the HIGH-confidence signal even at the plateau — "a multi-model finding
+is almost always a genuine deep tension, not noise."
+
+## The meta-move = the devlog principle, embodied in the tooling (the connective tissue)
+
+The response to all this wasn't just a code fix — it was **starting an append-only log of discoveries.**
+Commit `1694b113` created `SPEC-AUDIT-FAILURE-MODES.md` (a "well-known, append-only log") + a
+session-loaded stop-heuristic rule, with an entry format for future audits. The operator's framing is
+the perfect tie to this site's whole reason for existing:
+
+> **Operator (verbatim, in the rule's "why this exists"):** *"It's clearly harder and fuzzier to
+> determine when you've hit the diminishing-returns plateau than when auditing code. We should be
+> keeping a log… of our discoveries."*
+
+→ This is the **devlog thesis inside the machine.** The post is a devlog about discovering the
+barrage; the team is *simultaneously* keeping a devlog of what the barrage keeps teaching them. Worth
+landing explicitly: the work and the writing-about-the-work are the same practice. (And it makes the
+"we don't have all the answers" stance concrete — they built a *logbook for the answers they don't
+have yet.*)
+
+## How this lands in the outline
+
+- **§9 (governing the spec)** gets deepened from "extending left" into a real discovery beat: *we
+  pointed the same barrage at specs and it didn't behave the same way.* The `7→5→2→1→5→5→1` bounce,
+  the FM-2 generator, the "remove the mechanism, state the promise" break, the two plateau shapes, and
+  the override-as-honest-terminal-state.
+- It reinforces **discovery-first** (this is pure discovery, made this week) and **devlog** (literally
+  "keeping a log of our discoveries"; still mid-flight — 005 just graduated by override today).
+- Frame connection (use at most glancingly, per LIGHT dosage): selection pressure has to **fit the
+  substrate** — a code-shaped predator pointed at a spec selects for the wrong trait, so the
+  population never reaches a fitness peak. A different prey needs a differently-adapted predator. Note
+  it; don't belabor it.
+
+## Pull-quotes (verbatim, sourced)
+- (rule) "Auditing code has a crisp convergence floor ... Auditing a spec does not. A spec is prose —
+  inherently incomplete." — `spec-audit-diminishing-returns.md`
+- (commit) "the code-audit checklist ... was applied to specs too, telling the auditor to **litigate
+  IMPLEMENTATION in the spec**." — `ea7993e2`
+- (spec lens) "Look for flaws in *what the spec promises and decides*, never in *how it would be
+  built*." — `payload-spec.ts:SPEC_AUDIT_LENS`
+- (litmus) "WHAT → in scope ... HOW → OUT of scope." — `payload-spec.ts`
+- (log) "The plateau **was** the generator; removing it (not feeding it) converged it." — 005 entry
+- (operator) "version control is like a write journal… it lets you recover from corruption."
+- (operator) "We should be keeping a log… of our discoveries." — `spec-audit-diminishing-returns.md`
+- HIGH trajectory `7 → 5 → 2 → 1 → 5 → 5 → 1 → 4`; structural root-fix dropped 5→1; 39 findings / 8
+  iterations; graduated by override. — `SPEC-AUDIT-FAILURE-MODES.md`
+
+## Sources
+- `feature/stack-control` commits `ea7993e2`, `1694b113` (deskwork repo)
+- `plugins/stack-control/spec-kit/spec-governance/SPEC-AUDIT-FAILURE-MODES.md`
+- `.claude/rules/spec-audit-diminishing-returns.md`
+- `plugins/stack-control/src/govern/payload-spec.ts` (SPEC_AUDIT_LENS / SPEC_ARTIFACT_FRAMING)


### PR DESCRIPTION
Lands the first full draft of 'The Audit Barrage, Wired Into Every Task' plus its research/outline artifacts so it can be reviewed live on stackcontrol.org and iterated. Content-only: 10 files under the post dir, all additions. draft:false so it renders in prod (no one's reading yet; iterating live).